### PR TITLE
Add save settings button, Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean:
 	$(MAKE) -C $(buildDir) clean
 	
 cleanup_cache:
-	cd $(buildDir) && rm -rf *
+	rm -rf $(buildDir) && mkdir $(buildDir)
 	
 run: all
 	./bin/vision

--- a/src/app/gui/mainwindow.cpp
+++ b/src/app/gui/mainwindow.cpp
@@ -38,6 +38,9 @@ MainWindow::MainWindow(bool start_capture, bool enforce_affinity)
 
   root=new VarList("Vision System");
 
+  save_settings_trigger = new VarTrigger("Save Settings", "Save Settings!");
+  root->addChild(save_settings_trigger);
+
   opts=new RenderOptions();
   right_tab=0;
 
@@ -169,6 +172,10 @@ MainWindow::MainWindow(bool start_capture, bool enforce_affinity)
 
   startTimer(10);
 
+  // connection must be queued as the data tree is locked
+  // by a mutex when the signal is triggered
+  connect(save_settings_trigger, SIGNAL(signalTriggered()),
+          this, SLOT(slotSaveSettings()), Qt::QueuedConnection);
 }
 
 void MainWindow::timerEvent( QTimerEvent * e) {
@@ -190,6 +197,11 @@ void MainWindow::timerEvent( QTimerEvent * e) {
     }
     w->displayLoopEvent(frame_changed,opts);
   }
+}
+
+void MainWindow::slotSaveSettings()
+{
+    VarXML::write(world,"settings.xml");
 }
 
 void MainWindow::init() {

--- a/src/app/gui/mainwindow.h
+++ b/src/app/gui/mainwindow.h
@@ -64,6 +64,7 @@ public:
   vector<RealTimeDisplayWidget *> display_widgets;
   vector<QSplitter *> stack_widgets;
   RenderOptions * opts;
+  VarTrigger * save_settings_trigger;
 
   MultiVisionStack * multi_stack;
 
@@ -73,6 +74,9 @@ public:
   void Quit() { emit close(); }
   virtual void closeEvent(QCloseEvent * event );
   virtual void timerEvent(QTimerEvent * e);
+
+public slots:
+  void slotSaveSettings();
 };
 
 


### PR DESCRIPTION
Allows saving the current settings without closing ssl-vision.

The Makefile cleanup ensures that the users home is not deleted when calling "make cleanup_cache" without buildDir being set.