### PR TITLE
Feature/generate team

### DIFF
--- a/src/app/gui/glwidget.cpp
+++ b/src/app/gui/glwidget.cpp
@@ -326,7 +326,7 @@ void GLWidget::callZoomFit() {
 
 void GLWidget::callHelp() {
   QMessageBox::information ( this,"Keyboard and Mouse shortcuts",
-                             "Left-Click: Pick RGB Color\nShift-Modifier: Erase pixel from LUT\nCtrl-Modifier: Add pixel to LUT\nArrow-Keys (or Right-Drag Mouse): Panning\nPage Up/Down (or Mousewheel): Zooming\nHome: Reset Zoom to 100%\nSpace: Reset Zoom to Best Fit\nCtrl-f: Toggle Fullscreen\nCtrl-w: Toggle Detach Window" );
+                             "Left-Click: Pick RGB Color\nShift-Modifier: Erase pixel from LUT\nShift-Ctrl-Modifier: Add pixel to LUT\nArrow-Keys (or Right-Drag Mouse): Panning\nPage Up/Down (or Mousewheel): Zooming\nHome: Reset Zoom to 100%\nSpace: Reset Zoom to Best Fit\nCtrl-f: Toggle Fullscreen\nCtrl-w: Toggle Detach Window" );
 }
 
 void GLWidget::keyPressEvent ( QKeyEvent * event ) {

--- a/src/shared/capture/capture_generator.cpp
+++ b/src/shared/capture/capture_generator.cpp
@@ -17,11 +17,16 @@
   \brief   C++ Implementation: CaptureGenerator
   \author  Stefan Zickler, (C) 2009
 */
+// 2/4/16 - added ability to load team patterns from file (Zavesky)
 //========================================================================
 
 #include "capture_generator.h"
 #include "conversions.h"
 
+#include "cmpattern_team.h"         //added to load team files directly
+#include "cmpattern_teamdetector.h"
+
+#define TEAM_IMAGE_PLACEHOLDER      "(team images - reset bus to populate)"
 
 #ifndef VDATA_NO_QT
 CaptureGenerator::CaptureGenerator ( VarList * _settings, QObject * parent ) : QObject ( parent ), CaptureInterface ( _settings )
@@ -29,21 +34,26 @@ CaptureGenerator::CaptureGenerator ( VarList * _settings, QObject * parent ) : Q
 CaptureGenerator::CaptureGenerator ( VarList * _settings ) : CaptureInterface ( _settings )
 #endif
 {
-  is_capturing=false;
-
-  settings->addChild ( conversion_settings = new VarList ( "Conversion Settings" ) );
-  settings->addChild ( capture_settings = new VarList ( "Capture Settings" ) );
-
-  //=======================CONVERSION SETTINGS=======================
-  conversion_settings->addChild ( v_colorout=new VarStringEnum ( "convert to mode",Colors::colorFormatToString ( COLOR_YUV422_UYVY ) ) );
-  v_colorout->addItem ( Colors::colorFormatToString ( COLOR_RGB8 ) );
-  v_colorout->addItem ( Colors::colorFormatToString ( COLOR_YUV422_UYVY ) );
-
-  //=======================CAPTURE SETTINGS==========================
-  capture_settings->addChild ( v_framerate = new VarDouble ( "Framerate (FPS)", 60.0 ) );
-  capture_settings->addChild ( v_width = new VarInt ( "Width (pixels)", 780 ) );
-  capture_settings->addChild ( v_height = new VarInt ( "Height (pixels)", 580 ) );
-  capture_settings->addChild ( v_test_image = new VarBool ( "Generate Color Test Image", false ) );
+    is_capturing=false;
+    
+    settings->addChild ( conversion_settings = new VarList ( "Conversion Settings" ) );
+    settings->addChild ( capture_settings = new VarList ( "Capture Settings" ) );
+    
+    //=======================CONVERSION SETTINGS=======================
+    conversion_settings->addChild ( v_colorout=new VarStringEnum ( "convert to mode",Colors::colorFormatToString ( COLOR_YUV422_UYVY ) ) );
+    v_colorout->addItem ( Colors::colorFormatToString ( COLOR_RGB8 ) );
+    v_colorout->addItem ( Colors::colorFormatToString ( COLOR_YUV422_UYVY ) );
+    
+    //=======================CAPTURE SETTINGS==========================
+    capture_settings->addChild ( v_framerate = new VarDouble ( "Framerate (FPS)", 60.0 ) );
+    capture_settings->addChild ( v_width = new VarInt ( "Width (pixels)", 780 ) );
+    capture_settings->addChild ( v_height = new VarInt ( "Height (pixels)", 580 ) );
+    
+    //modified 2/5/16 to allow generator to generate team patterns, E. Zavesky
+    capture_settings->addChild( v_test_image = new VarStringEnum("Generate Mode", "none"));
+    v_test_image->addItem("none");
+    v_test_image->addItem("test image");
+    v_test_image->addItem(TEAM_IMAGE_PLACEHOLDER);
 }
 
 CaptureGenerator::~CaptureGenerator()
@@ -80,6 +90,29 @@ bool CaptureGenerator::startCapture()
   mutex.unlock();
 #endif
   return true;
+}
+
+bool CaptureGenerator::resetBus()
+{
+    v_test_image->setSize(3);       //trim off prior settings
+    v_test_image->selectIndex(0);   //force selection off of prior
+    vectImages.clear();
+    
+    std::vector<VarType *> vectRelatives = settings->findRelatives("Teams", true);  //find Teams node
+    if (vectRelatives.size() < 1) return false;
+
+    VarType *pTeams = vectRelatives[0];    //jump to head
+    std::vector<VarType *> vectTeamNodes = pTeams->getChildren();
+    for (int iTeam=0; iTeam<vectTeamNodes.size(); iTeam++) {
+        VarType *pTeam = vectTeamNodes[iTeam];
+        std::vector<VarType *> vectImageNodes = pTeam->findRelatives("Marker Image File");  //find image node
+        if (vectImageNodes.size()==1) {
+            VarString *pString = reinterpret_cast<VarString*>(vectImageNodes[0]);
+            vectImages.push_back(pString->getString());             // add filename
+            v_test_image->addItem(pTeam->getName());                    // add team name
+        }
+    }
+    return true;
 }
 
 bool CaptureGenerator::copyAndConvertFrame ( const RawImage & src, RawImage & target )
@@ -122,58 +155,83 @@ bool CaptureGenerator::copyAndConvertFrame ( const RawImage & src, RawImage & ta
 RawImage CaptureGenerator::getFrame()
 {
 #ifndef VDATA_NO_QT
-  mutex.lock();
+    mutex.lock();
 #endif
-  limit.waitForNextFrame();
-  result.setColorFormat ( COLOR_RGB8 );
-  result.setTime ( GetTimeSec() );
-  result.allocate ( COLOR_RGB8,v_width->getInt(),v_height->getInt() );
-  rgbImage img;
-  img.fromRawImage(result);
-
-  if (v_test_image->getBool()) {
-    int w = result.getWidth();
-    int h = result.getHeight();
-    int n_colors = 8;
-    int slice_width = w/n_colors;
-    rgb color=RGB::Black;
-    rgb color2;
-    int gradient=h/256;
-    for (int x = 0 ; x < w; x++) {
-      int c_idx= x/slice_width;
-      if (c_idx==0) {
-        color=RGB::White;
-      } else if (c_idx==1) {
-        color=RGB::Red;
-      } else if (c_idx==2) {
-        color=RGB::Green;
-      } else if (c_idx==3) {
-        color=RGB::Blue;
-      } else if (c_idx==4) {
-        color=RGB::Cyan;
-      } else if (c_idx==5) {
-        color=RGB::Pink;
-      } else if (c_idx==6) {
-        color=RGB::Yellow;
-      } else if (c_idx==7) {
-        color=RGB::Black;
-      }
-      for (int y = 0 ; y < h; y++) {
-        color2.r= max(0,min(255,((int)color.r * (h-1-y))/h));
-        color2.g= max(0,min(255,((int)color.g * (h-1-y))/h));
-        color2.b= max(0,min(255,((int)color.b * (h-1-y))/h));
-        img.setPixel(x,y,color2);
-      }
+    limit.waitForNextFrame();
+    result.setColorFormat ( COLOR_RGB8 );
+    result.setTime ( GetTimeSec() );
+    result.allocate ( COLOR_RGB8,v_width->getInt(),v_height->getInt() );
+    rgbImage img;
+    img.fromRawImage(result);
+    
+    std::string sTestImage = v_test_image->getString();
+    if (state_prior == sTestImage) {      //don't waste time reloading/drawing
+        img.copy(img_prior);
     }
-  } else {
-    img.fillBlack();
-  }
-
-
+    else {
+        if (sTestImage=="test image") {
+            int w = result.getWidth();
+            int h = result.getHeight();
+            int n_colors = 8;
+            int slice_width = w/n_colors;
+            rgb color=RGB::Black;
+            rgb color2;
+            int gradient=h/256;
+            for (int x = 0 ; x < w; x++) {
+                int c_idx= x/slice_width;
+                if (c_idx==0) {
+                    color=RGB::White;
+                } else if (c_idx==1) {
+                    color=RGB::Red;
+                } else if (c_idx==2) {
+                    color=RGB::Green;
+                } else if (c_idx==3) {
+                    color=RGB::Blue;
+                } else if (c_idx==4) {
+                    color=RGB::Cyan;
+                } else if (c_idx==5) {
+                    color=RGB::Pink;
+                } else if (c_idx==6) {
+                    color=RGB::Yellow;
+                } else if (c_idx==7) {
+                    color=RGB::Black;
+                }
+                for (int y = 0 ; y < h; y++) {
+                    color2.r= max(0,min(255,((int)color.r * (h-1-y))/h));
+                    color2.g= max(0,min(255,((int)color.g * (h-1-y))/h));
+                    color2.b= max(0,min(255,((int)color.b * (h-1-y))/h));
+                    img.setPixel(x,y,color2);
+                }
+            }
+        } else if (sTestImage=="none" || sTestImage==TEAM_IMAGE_PLACEHOLDER) {
+            img.fillBlack();
+        } else {                                    //otherwise, we have a team image...
+            int iIdx = v_test_image->getIndex()-3;
+            if (vectImages.size() < iIdx) {
+                std::string sPath = vectImages[iIdx];    //copy filepath from second list
+                fprintf ( stderr,"CaptureGenerator: Attempting to load image '%s' for team '%s'...\n",
+                         sPath.c_str(), sTestImage.c_str());
+                
+                rgbImage img_load;
+                if (!img_load.load(sPath))
+                    img.fillBlack();
+                else {
+                    img.fillBlack();
+                    int w = (result.getWidth() > img_load.getWidth()) ? img_load.getWidth() : result.getWidth();
+                    int h = (result.getHeight() > img_load.getHeight()) ? img_load.getHeight() : result.getHeight();
+                    img.copyFromRectArea(img_load, 0, 0, w, h, true);
+                }
+            }
+        }
+        img_prior.copy(img);                        //save for next round
+        state_prior = v_test_image->getString();    //update new state
+    }
+    
+    
 #ifndef VDATA_NO_QT
-  mutex.unlock();
+    mutex.unlock();
 #endif
-  return result;
+    return result;
 }
 
 void CaptureGenerator::releaseFrame()

--- a/src/shared/capture/capture_generator.h
+++ b/src/shared/capture/capture_generator.h
@@ -55,6 +55,7 @@ class CaptureGenerator : public CaptureInterface
 protected:
   bool is_capturing;
   RawImage result;
+  int iForcedFrames;
     
   std::string state_prior;
   rgbImage img_prior;

--- a/src/shared/capture/capture_generator.h
+++ b/src/shared/capture/capture_generator.h
@@ -70,7 +70,6 @@ protected:
   VarInt * v_height;
   VarDouble * v_framerate;
   VarStringEnum * v_test_image;
-  std::vector<std::string> vectImages;
   
 public:
 #ifndef VDATA_NO_QT

--- a/src/shared/capture/capture_generator.h
+++ b/src/shared/capture/capture_generator.h
@@ -55,6 +55,10 @@ class CaptureGenerator : public CaptureInterface
 protected:
   bool is_capturing;
   RawImage result;
+    
+  std::string state_prior;
+  rgbImage img_prior;
+
   FrameLimiter limit;
   //processing variables:
   VarStringEnum * v_colorout;
@@ -65,7 +69,8 @@ protected:
   VarInt * v_width;
   VarInt * v_height;
   VarDouble * v_framerate;
-  VarBool * v_test_image;
+  VarStringEnum * v_test_image;
+  std::vector<std::string> vectImages;
   
 public:
 #ifndef VDATA_NO_QT
@@ -79,7 +84,8 @@ public:
   virtual bool startCapture();
   virtual bool stopCapture();
   virtual bool isCapturing() { return is_capturing; };
-  
+  virtual bool resetBus();
+
   virtual RawImage getFrame();
   virtual void releaseFrame();
    

--- a/src/shared/vartypes/primitives/VarList.h
+++ b/src/shared/vartypes/primitives/VarList.h
@@ -65,7 +65,15 @@ namespace VarTypes {
     virtual void printdebug() const { printf("VarList named %s containing %zu element(s)\n",getName().c_str(), list.size()); }
 
     /// adds a VarType item to the end of the list.
-    int addChild(VarType * child) { lock(); list.push_back(child); emit(childAdded(child)); unlock(); changed(); return (list.size()-1);}
+    int addChild(VarType * child) {
+        lock();
+        child->setParent(this);          //added 2/4/16 for parent/child search
+        list.push_back(child);
+        emit(childAdded(child));
+        unlock();
+        changed();
+        return (list.size()-1);
+    }
     bool removeChild(VarType * child) {
       lock();
       vector<VarType *> newlist;

--- a/src/shared/vartypes/primitives/VarStringEnum.h
+++ b/src/shared/vartypes/primitives/VarStringEnum.h
@@ -119,15 +119,15 @@ namespace VarTypes {
   
     /// get the string of item at a given index
     string getLabel(unsigned int index) const {
-    string result="";
-    lock();
-    if (index > (list.size() - 1)) {
-      result="";
-    } else {
-      result=((VarString *)(list[index]))->getString();
-    }
-    unlock();
-    return result;
+        string result="";
+        lock();
+        if (index > (list.size() - 1)) {
+          result="";
+        } else {
+          result=((VarString *)(list[index]))->getString();
+        }
+        unlock();
+        return result;
     }
   
     /// trim or extend the list to a certain total number of items
@@ -152,19 +152,19 @@ namespace VarTypes {
   
     /// set the string of item at a given index
     void setLabel(unsigned int index, const string & label) {
-    string result="";
-    lock();
-    if (index < list.size()) {
-      if (((VarString *)(list[index]))->getString().compare(selected)==0) {
-        selected=label;
-      }
-      ((VarString *)(list[index]))->setString(label);
-      
-    }
-    
-    unlock();
-    changed();
-    return;
+        string result="";
+        lock();
+        if (index < list.size()) {
+          if (((VarString *)(list[index]))->getString().compare(selected)==0) {
+            selected=label;
+          }
+          ((VarString *)(list[index]))->setString(label);
+          
+        }
+        
+        unlock();
+        changed();
+        return;
     }
   
     /// add an item to the end of the enumeration

--- a/src/shared/vartypes/primitives/VarType.h
+++ b/src/shared/vartypes/primitives/VarType.h
@@ -139,6 +139,7 @@ namespace VarTypes {
     #endif
     VarTypeFlag _flags;
     string _name;
+    VarType * _parent;
     static string fixString(const char * cst);
     static string intToString(int val);
     static string doubleToString(double val);
@@ -196,7 +197,14 @@ namespace VarTypes {
     /// Finds a child based on its label
     /// Returns 0 if not found
     VarType * findChild(string label) const;
+
+    /// Finds all relatives (parent/children) based on its label (warning, can be costly)
+    /// Returns empty if not found
+    std::vector<VarType *> findRelatives(string label, bool bSearchAncestors=false) const;
   
+    /// Utility function for lists and the like to inform their progeny
+    inline void setParent(VarType *parent) { _parent = parent; };
+      
     /// TODO: implement this function. It might be useful for some purposes.
     /// VarType * merge(VarType * structure, VarType * data);
   


### PR DESCRIPTION
* add a new mode to inject team codes into generator for easier LUT training (see image); towards easier LUT sync across cameras (requested in [legacy TODO](https://github.com/RoboCup-SSL/ssl-vision/blob/wiki/TODO.md))
* add a method to search for nodes in VarType tree (allows settings from one module to be pulled into another -- like teams into capture_generator)
* optimize generator to cache frames instead of always redrawing; doubled frame rate throughput

![160205_generate_team](https://cloud.githubusercontent.com/assets/12480297/12847898/2311c10c-cbdc-11e5-8e35-b4c34cc2f642.jpg)
