### PR TITLE
Hotfix/live lut update

### DIFF
--- a/src/app/gui/glLUTwidget.cpp
+++ b/src/app/gui/glLUTwidget.cpp
@@ -329,6 +329,7 @@ void GLLUTWidget::add_del_Pixel(yuv color, bool add, bool continuing_undo)
 
   slices[state.slice_idx]->selection_update_pending=true;
   _lut->unlock();
+  _lut->updateDerivedLUTs();
 
   this->redraw();
 }

--- a/src/shared/capture/capturev4l.cpp
+++ b/src/shared/capture/capturev4l.cpp
@@ -577,8 +577,11 @@ CaptureV4L::CaptureV4L(VarList * _settings,int default_camera_id) : CaptureInter
     }
     
     if (cam_id > cam_list[cam_count-1]) {
-        //fprintf(stderr,"CaptureV4L Error: no camera found with index %d. Max index is: %d\n",cam_id,cam_list[cam_count-1]);   /// 2/5/16 --- shh, please be quiet
-        ;
+        static bool bMaxWarningShown = false;
+        if (!bMaxWarningShown) {
+            fprintf(stderr,"CaptureV4L Error: no camera found with index %d. Max index is: %d\n",cam_id,cam_list[cam_count-1]);
+            bMaxWarningShown = true;
+        }
     }
     else {
         camera_instance = GlobalV4LinstanceManager::obtainInstance(cam_id);


### PR DESCRIPTION
* update to sync LUT when colors from live video are added (ctrl+shift+click) or removed (shift+click)
   * previously, LUT was updated, but derived tables were not, which means no processing update
* one minor tweak for printing errors in v4l module (instead of hiding all responses)
* update URL from old google code pointer to github