### PR TITLE
Feature/lut copy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ qt4_wrap_cpp (MOC_SRCS
 	src/app/plugins/plugin_publishgeometry.h
 	src/app/plugins/plugin_legacypublishgeometry.h
 	src/app/plugins/visionplugin.h
+	src/app/plugins/plugin_colorcalib.h
 	
 	src/app/stacks/multistack_robocup_ssl.h
 )

--- a/src/app/gui/glLUTwidget.cpp
+++ b/src/app/gui/glLUTwidget.cpp
@@ -897,9 +897,11 @@ void GLLUTWidget::setLUT(LUT3D * lut) {
 }
 
 bool GLLUTWidget::copyLUT(void *pDataLUT, int size_copy, int color_index) {
-    editStore();                            //edit snapshot
+    //edit snapshot
+    editStore();                            
     m.lock();
-    bool bSuccess = _lut->copyLUT(pDataLUT, size_copy, color_index);  //perform actual copy
+    //perform actual copy
+    bool bSuccess = _lut->copyLUT(pDataLUT, size_copy, color_index);  
     m.unlock();
     if (bSuccess) rebuildAndRedraw();
     return bSuccess;

--- a/src/app/gui/glLUTwidget.cpp
+++ b/src/app/gui/glLUTwidget.cpp
@@ -896,6 +896,15 @@ void GLLUTWidget::setLUT(LUT3D * lut) {
   m.unlock();
 }
 
+bool GLLUTWidget::copyLUT(void *pDataLUT, int size_copy, int color_index) {
+    editStore();                            //edit snapshot
+    m.lock();
+    bool bSuccess = _lut->copyLUT(pDataLUT, size_copy, color_index);  //perform actual copy
+    m.unlock();
+    if (bSuccess) rebuildAndRedraw();
+    return bSuccess;
+}
+
 void GLLUTWidget::init() {
   if (_lut!=0) {
     int z=_lut->getSizeX();

--- a/src/app/gui/glLUTwidget.h
+++ b/src/app/gui/glLUTwidget.h
@@ -202,6 +202,7 @@ protected:
 
 public:
   void setLUT(LUT3D * lut);
+  bool copyLUT(void *pDataLUT, int size_copy, int color_index=-1);
   virtual void init();
 
   VideoStats stats;

--- a/src/app/plugins/plugin_colorcalib.cpp
+++ b/src/app/plugins/plugin_colorcalib.cpp
@@ -31,7 +31,7 @@ PluginColorCalibration::PluginColorCalibration(FrameBuffer * _buffer, YUVLUT * _
     settings=new VarList("YUV Calibrator");
     continuing_undo = false;
     
-    copy_LUT_trigger = new VarTrigger("Copy LUT", "Copy LUT!");
+    copy_LUT_trigger = new VarTrigger("Copy LUT", "Copy LUT");
     settings->addChild(copy_LUT_trigger);
     connect(copy_LUT_trigger,SIGNAL(signalTriggered()),this,SLOT(slotCopyLUT()));
     settings->addChild( v_lut_sources = new VarStringEnum("LUT Source", LUT_COPY_PLACEHOLDER));
@@ -187,7 +187,7 @@ void PluginColorCalibration::copyLUT() {            //perform memory copy of oth
         int color_index = -1;       //default -1 is ALL colors; TODO be from var 'v_lut_colors'
         std::vector<VarType *> vectTarget = settings->findRelatives(v_lut_sources->getString(), true);
         if (vectTarget.size()!=1) {
-            fprintf(stderr, "LUT3D: Found too many cameara nodes (%d) for camera '%s', aborting copy.\n",
+            fprintf(stderr, "LUT3D: Found too many camera nodes (%d) for camera '%s', aborting copy.\n",
                     static_cast<int>(vectTarget.size()), v_lut_sources->getString().c_str());
             bSuccess = false;
         }

--- a/src/app/plugins/plugin_colorcalib.cpp
+++ b/src/app/plugins/plugin_colorcalib.cpp
@@ -21,13 +21,23 @@
 #include "plugin_colorcalib.h"
 #include <QStackedWidget>
 
+#define LUT_COPY_PLACEHOLDER    "(click copy to refresh)"
+
 PluginColorCalibration::PluginColorCalibration(FrameBuffer * _buffer, YUVLUT * _lut, LUTChannelMode _mode) : VisionPlugin(_buffer)
 {
-  mode=_mode;
-  lut=_lut;
-  lutw=0;
-  settings=new VarList("YUV Calibrator");
-  continuing_undo = false;
+    mode=_mode;
+    lut=_lut;
+    lutw=0;
+    settings=new VarList("YUV Calibrator");
+    continuing_undo = false;
+    
+    copy_LUT_trigger = new VarTrigger("Copy LUT", "Copy LUT!");
+    settings->addChild(copy_LUT_trigger);
+    connect(copy_LUT_trigger,SIGNAL(signalTriggered()),this,SLOT(slotCopyLUT()));
+    settings->addChild( v_lut_sources = new VarStringEnum("LUT Source", LUT_COPY_PLACEHOLDER));
+    v_lut_sources->addItem(LUT_COPY_PLACEHOLDER);
+    settings->addChild( v_lut_colors = new VarStringEnum("Color", LUT_COPY_PLACEHOLDER));
+    v_lut_colors->addItem(LUT_COPY_PLACEHOLDER);
 }
 
 VarList * PluginColorCalibration::getSettings() {
@@ -40,7 +50,10 @@ string PluginColorCalibration::getName() {
 
 PluginColorCalibration::~PluginColorCalibration()
 {
-  delete settings;
+    delete settings;
+    delete copy_LUT_trigger;
+    delete v_lut_sources;
+    delete v_lut_colors;
 }
 
 QWidget * PluginColorCalibration::getControlWidget() {
@@ -140,3 +153,67 @@ void PluginColorCalibration::mouseReleaseEvent ( QMouseEvent * event, pixelloc l
 void PluginColorCalibration::mouseMoveEvent ( QMouseEvent * event, pixelloc loc ) {
   mouseEvent(event,loc);
 }
+
+void PluginColorCalibration::slotCopyLUT() {
+    copyLUT();            //perform memory copy of other camera LUT
+}
+
+void PluginColorCalibration::copyLUT() {            //perform memory copy of other camera LUT
+    //TODO: replace with a method that can fetch known colors
+    // use: v_lut_colors->addItem("all");
+    if (v_lut_sources->getCount()==1 && v_lut_sources->getString()==LUT_COPY_PLACEHOLDER) {
+        VarString *pSelf = reinterpret_cast<VarString*>(settings->getParent());
+        std::vector<VarType *> vectRelatives = settings->findRelatives("LUT 3D", true);  //find LUT3D nodes node
+        if (vectRelatives.size() < 1) {     //nothing like LUTs? abort
+            fprintf(stderr, "LUT3D: Could not find any LUT3D nodes for sources, aborting copy.\n");
+        }
+        else {
+            v_lut_sources->setSize(0);          //truncate/clear former list
+            for (int iCam=0; iCam<vectRelatives.size(); iCam++) {
+                VarString *pCamera = reinterpret_cast<VarString*>(vectRelatives[iCam]->getParent()->getParent());
+                if (pCamera != pSelf)
+                    v_lut_sources->addItem(pCamera->getName());
+            }
+            if (!vectRelatives.empty())
+                v_lut_sources->selectIndex(0);
+            v_lut_colors->setSize(0);          //truncate/clear former list
+            v_lut_colors->addItem("all");
+            v_lut_colors->selectIndex(0);
+        }
+    }
+    else {              //user has selected a camera
+        bool bSuccess = true;
+        VarBlob *pSource = NULL;
+        int color_index = -1;       //default -1 is ALL colors; TODO be from var 'v_lut_colors'
+        std::vector<VarType *> vectTarget = settings->findRelatives(v_lut_sources->getString(), true);
+        if (vectTarget.size()!=1) {
+            fprintf(stderr, "LUT3D: Found too many cameara nodes (%d) for camera '%s', aborting copy.\n",
+                    static_cast<int>(vectTarget.size()), v_lut_sources->getString().c_str());
+            bSuccess = false;
+        }
+        else {
+            vectTarget = vectTarget[0]->findRelatives("LUT Data", false);  //just children
+        }
+        if (bSuccess && vectTarget.size()!=1) {
+            fprintf(stderr, "LUT3D: Found too many LUT nodes (%d) for camera '%s', aborting copy.\n",
+                    static_cast<int>(vectTarget.size()), v_lut_sources->getString().c_str());
+            bSuccess = false;
+        }
+        else {
+            pSource = reinterpret_cast<VarBlob*>(vectTarget[0]);
+            
+            //WARNING: Makes assumption that all LUT blobs have the same properties
+            //  (e.g. same initializer, etc) because we do not reallocate, modify shift
+            //  indicies, or anything else dramatic.  This is an acceptable risk because
+            //  the constructor for this class just loops to add multiple camera sources.
+            //  (added corresponding warning in multistack_robocup_ssl.cpp at allocation)
+            
+            GLLUTWidget *pGLLUTw = lutw->getGLLUTWidget();
+            if (pGLLUTw->copyLUT(pSource->getDataPointer(), pSource->getDataSize(), color_index)) {
+                fprintf(stderr, "PluginColorCalibration: Successful copy of LUT data from camera '%s'.\n",
+                        v_lut_sources->getString().c_str());
+            }
+        }
+    }
+}
+

--- a/src/app/plugins/plugin_colorcalib.h
+++ b/src/app/plugins/plugin_colorcalib.h
@@ -30,20 +30,27 @@
 /**
 	@author Stefan Zickler <szickler@cs.cmu.edu>
 */
-class PluginColorCalibration : public VisionPlugin {
+class PluginColorCalibration : public VisionPlugin
+{
+Q_OBJECT
 protected:
     YUVLUT * lut;
     VarList * settings;
     LUTWidget * lutw;
+    VarStringEnum * v_lut_sources;
+    VarStringEnum * v_lut_colors;
+    VarTrigger * copy_LUT_trigger;
     LUTChannelMode mode;
     bool continuing_undo;
     void mouseEvent ( QMouseEvent * event, pixelloc loc );
+    void copyLUT();
+protected slots:
+    void slotCopyLUT();
 public:
-
     PluginColorCalibration(FrameBuffer * _buffer, YUVLUT * _lut, LUTChannelMode _mode=LUTChannelMode_Numeric);
     virtual VarList * getSettings();
     virtual string getName();
-    ~PluginColorCalibration();
+    virtual ~PluginColorCalibration();
     virtual QWidget * getControlWidget();
 
     virtual void keyPressEvent ( QKeyEvent * event );

--- a/src/app/stacks/multistack_robocup_ssl.cpp
+++ b/src/app/stacks/multistack_robocup_ssl.cpp
@@ -87,6 +87,10 @@ MultiStackRoboCupSSL::MultiStackRoboCupSSL(RenderOptions * _opts, int cameras) :
   createThreads(cameras);
   unsigned int n = threads.size();
   for (unsigned int i = 0; i < n;i++) {
+    //NOTE: if modified to put different stacks in cameras, please
+    //      update the plugin_colorcalib.cpp code to safely reallocate and copy their
+    //      data instead of assuming that format and size is uniform across
+    //      cameras -- added when LUTs became aware of other cameras (Zavesky, 2/16)
     threads[i]->setFrameBuffer(new FrameBuffer(5));
     threads[i]->setStack(
         new StackRoboCupSSL(
@@ -102,7 +106,6 @@ MultiStackRoboCupSSL::MultiStackRoboCupSSL(RenderOptions * _opts, int cameras) :
             ds_udp_server_old,
             "robocup-ssl-cam-" + QString::number(i).toStdString()));
   }
-  //TODO: make LUT widgets aware of each other for easy data-sharing
 }
 
 string MultiStackRoboCupSSL::getSettingsFileName() {

--- a/src/shared/util/lut3d.h
+++ b/src/shared/util/lut3d.h
@@ -34,7 +34,7 @@
     { sp->xl = XL; sp->xr = XR; sp->y = Y; sp->dy = DY; ++sp; }
 #define LUTFILL_POP(XL, XR, Y, DY) \
     { --sp; XL = sp->xl; XR = sp->xr; Y = sp->y+(DY = sp->dy); }
-    
+
 
 /// We allow 32 distinct channels (bitwise)
 typedef uint8_t lut_mask_t;
@@ -139,6 +139,24 @@ class LUT3D : public QObject {
       reset();
     };
 
+    bool copyLUT(void *pDataLUT, int size_copy, int color_index=-1) {   //memory copy of other camera LUT
+        if (color_index!=-1) {
+            fprintf(stderr, "LUT3D: Color-specific copy currently unavailable.\n");
+            return false;
+        }
+        
+        int size_allocated = LUT ? sizeof(lut_mask_t)*LUT_SIZE : 0;
+        if (size_copy!=size_allocated) {
+            fprintf(stderr, "LUT3D: Size mismatch for LUT nodes (current: %d vs source: %d), aborting copy.\n",
+                    size_allocated, size_copy);
+            return false;
+        }
+        lock();                             //step 1: copy LUT from blob
+        memcpy(LUT, pDataLUT, sizeof(lut_mask_t)*LUT_SIZE);
+        unlock();
+        updateDerivedLUTs();                //step 2: rederive from self
+    }
+    
     void lock() {
       mutex.lock();
     }

--- a/src/shared/vartypes/primitives/VarList.h
+++ b/src/shared/vartypes/primitives/VarList.h
@@ -65,7 +65,15 @@ namespace VarTypes {
     virtual void printdebug() const { printf("VarList named %s containing %zu element(s)\n",getName().c_str(), list.size()); }
 
     /// adds a VarType item to the end of the list.
-    int addChild(VarType * child) { lock(); list.push_back(child); emit(childAdded(child)); unlock(); changed(); return (list.size()-1);}
+    int addChild(VarType * child) {
+        lock();
+        child->setParent(this);          //added 2/4/16 for parent/child search
+        list.push_back(child);
+        emit(childAdded(child));
+        unlock();
+        changed();
+        return (list.size()-1);
+    }
     bool removeChild(VarType * child) {
       lock();
       vector<VarType *> newlist;

--- a/src/shared/vartypes/primitives/VarStringEnum.h
+++ b/src/shared/vartypes/primitives/VarStringEnum.h
@@ -119,15 +119,15 @@ namespace VarTypes {
   
     /// get the string of item at a given index
     string getLabel(unsigned int index) const {
-    string result="";
-    lock();
-    if (index > (list.size() - 1)) {
-      result="";
-    } else {
-      result=((VarString *)(list[index]))->getString();
-    }
-    unlock();
-    return result;
+        string result="";
+        lock();
+        if (index > (list.size() - 1)) {
+          result="";
+        } else {
+          result=((VarString *)(list[index]))->getString();
+        }
+        unlock();
+        return result;
     }
   
     /// trim or extend the list to a certain total number of items
@@ -152,19 +152,19 @@ namespace VarTypes {
   
     /// set the string of item at a given index
     void setLabel(unsigned int index, const string & label) {
-    string result="";
-    lock();
-    if (index < list.size()) {
-      if (((VarString *)(list[index]))->getString().compare(selected)==0) {
-        selected=label;
-      }
-      ((VarString *)(list[index]))->setString(label);
-      
-    }
-    
-    unlock();
-    changed();
-    return;
+        string result="";
+        lock();
+        if (index < list.size()) {
+          if (((VarString *)(list[index]))->getString().compare(selected)==0) {
+            selected=label;
+          }
+          ((VarString *)(list[index]))->setString(label);
+          
+        }
+        
+        unlock();
+        changed();
+        return;
     }
   
     /// add an item to the end of the enumeration

--- a/src/shared/vartypes/primitives/VarType.h
+++ b/src/shared/vartypes/primitives/VarType.h
@@ -204,6 +204,9 @@ namespace VarTypes {
   
     /// Utility function for lists and the like to inform their progeny
     inline void setParent(VarType *parent) { _parent = parent; };
+
+    /// Utility function for any node to get its parent
+    inline VarType * getParent() const { return _parent; };
       
     /// TODO: implement this function. It might be useful for some purposes.
     /// VarType * merge(VarType * structure, VarType * data);

--- a/src/shared/vartypes/primitives/VarType.h
+++ b/src/shared/vartypes/primitives/VarType.h
@@ -139,6 +139,7 @@ namespace VarTypes {
     #endif
     VarTypeFlag _flags;
     string _name;
+    VarType * _parent;
     static string fixString(const char * cst);
     static string intToString(int val);
     static string doubleToString(double val);
@@ -196,7 +197,14 @@ namespace VarTypes {
     /// Finds a child based on its label
     /// Returns 0 if not found
     VarType * findChild(string label) const;
+
+    /// Finds all relatives (parent/children) based on its label (warning, can be costly)
+    /// Returns empty if not found
+    std::vector<VarType *> findRelatives(string label, bool bSearchAncestors=false) const;
   
+    /// Utility function for lists and the like to inform their progeny
+    inline void setParent(VarType *parent) { _parent = parent; };
+      
     /// TODO: implement this function. It might be useful for some purposes.
     /// VarType * merge(VarType * structure, VarType * data);
   


### PR DESCRIPTION
**NOTE** This is a refactored pull request from #41 that excludes team pattern changes.
-  add button in "YUV Calibrator" to copy LUT from other cameras (solving [legacy request](https://github.com/RoboCup-SSL/ssl-vision/blob/wiki/TODO.md) to allow easy LUT channel sync)
  - **NOTE** builds on some vartype changes in PR #39 
  - a space to limit which color is copied, but not currently implemented (let's gauge the interest first)
- update vartype to allow access to parent node

![160207_lut_copy](https://cloud.githubusercontent.com/assets/12480297/12884614/15fe453a-ce25-11e5-8eb4-33c086ff8423.png)
