### PR TITLE
hotfix/v4l_crash_on_start

### DIFF
--- a/src/shared/capture/capturev4l.cpp
+++ b/src/shared/capture/capturev4l.cpp
@@ -1146,6 +1146,7 @@ bool CaptureV4L::startCapture()
 #ifndef VDATA_NO_QT
         mutex.unlock();
 #endif
+        return false;
     }
     
     //grab current parameters:


### PR DESCRIPTION
* missed a error return (addending 357321a69f071a8a3958f3156b0e2bd08c55202a) which caused crash if device unavailable (like using '-s' when launching app)
   * follow-up fix to PR #44 