### PR TITLE
Fix LUT single slice view.

### DIFF
--- a/src/app/gui/glLUTwidget.cpp
+++ b/src/app/gui/glLUTwidget.cpp
@@ -782,11 +782,12 @@ void GLLUTWidget::glDrawSlice(Slice * s) {
         glVertex3f(1.0 ,0.0  ,z+z_offset);
       glEnd();
     }
-    glEnable(GL_COLOR_LOGIC_OP);
-    //glLogicOp(GL_COPY_INVERTED);
-    //glLogicOp(GL_XOR);
-    glLogicOp(GL_EQUIV);                //fix drawing inverted color (2/2/16)
     if (s->sampler->bind()) {
+      glEnable(GL_COLOR_LOGIC_OP);
+      // invert color+alpha below the sampling marks to ensure visibility
+      // testing this operation should be done when only a single slice is displayed
+      // the other views seem to always draw the sample marks due to scaling artifacts
+      glLogicOp(GL_XOR);
       glBegin(GL_QUADS);
         glTexCoord2f(0.0,0.0);
         glVertex3f(0.0  ,0.0,z+z_offset*2);
@@ -800,9 +801,8 @@ void GLLUTWidget::glDrawSlice(Slice * s) {
         glTexCoord2f(1.0,0.0);
         glVertex3f(1.0 ,0.0  ,z+z_offset*2);
       glEnd();
+      glDisable(GL_COLOR_LOGIC_OP);
     }
-    glDisable(GL_COLOR_LOGIC_OP);
-
   }
   glPopMatrix();
 }


### PR DESCRIPTION
This commit reverts 8bea8d5f151c8af0c894d3310000b181da8e98e2 and cleans up the existing code.

The sampler layer is either transparent black or solid white. The transparent black parts are ignored when drawing.
Using xor with solid white is identical to inverting a pixel. GL_EQUIV is the exact opposite of xor, that is solid white causes no pixel changes and transparent black apparently too.
The views other than single slice view seem to always draw the sample marks due to scaling artifacts (switch to cube mode and move the camera near and far away from the cube).

Using GL_EQUIV break the single slice view, which is probably the most important one for doing color calibration.