### PR TITLE
Load field defaults if no lines and arcs are configured

### DIFF
--- a/src/shared/util/field.cpp
+++ b/src/shared/util/field.cpp
@@ -311,6 +311,8 @@ RoboCupField::RoboCupField() {
           this, SLOT(ProcessNewFieldLines()));
   connect(field_arcs_list, SIGNAL(XMLwasRead(VarType*)),
           this, SLOT(ProcessNewFieldArcs()));
+  connect(settings,SIGNAL(XMLwasRead(VarType*)),
+          this, SLOT(InjectDefaults()));
 
   emit calibrationChanged();
 }
@@ -515,4 +517,14 @@ void RoboCupField::ResizeFieldArcs() {
             "%s:%d\n", __FILE__, __LINE__);
   }
   field_markings_mutex.unlock();
+}
+
+void RoboCupField::InjectDefaults() {
+  field_markings_mutex.lockForWrite();
+  const size_t num_lines = static_cast<size_t>(var_num_lines->getInt());
+  const size_t num_arcs = static_cast<size_t>(var_num_arcs->getInt());
+  field_markings_mutex.unlock();
+  if (num_lines == 0 && num_arcs == 0) {
+    loadDefaultsRoboCup2012();
+  }
 }

--- a/src/shared/util/field.h
+++ b/src/shared/util/field.h
@@ -161,6 +161,7 @@ protected slots:
   void ProcessNewFieldArcs();
   void ResizeFieldLines();
   void ResizeFieldArcs();
+  void InjectDefaults();
   void changed() {
     calibrationChanged();
   }


### PR DESCRIPTION
When ssl-vision is started for the first time, no lines and arcs are added. Getting a working configuration requires clicking the "Reset SSL 2014"-button. This patch automatically loads the defaults if no lines and arcs are set.

A different implementation would be to set the defaults if no settings file exists. The implementation in my patch will, however, also work with existing configurations that lack field lines.