### PR TITLE
Fix compiler warnings and default to -Wall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,8 +129,10 @@ elseif (${arch} MATCHES "x86")
 	set (cc_flags "")
 endif()
 
-# make sure to use C++98
+# make sure to use C++98 and enable warnings
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ansi")
+# enable warnings
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
 #flags to set in debug mode
 set (CMAKE_CXX_FLAGS_DEBUG "-g -Wl,--no-as-needed")

--- a/src/app/gui/glLUTwidget.cpp
+++ b/src/app/gui/glLUTwidget.cpp
@@ -28,7 +28,7 @@ void GLLUTWidget::editUndo() {
     UndoState * s=undoStack.back();
     UndoState * r=new UndoState(_lut);
     s->restore(_lut);
-    for(int i=0; i<slices.size(); i++)
+    for(size_t i=0; i<slices.size(); i++)
       drawSlice(slices[i],_lut, i, false,true,false);
     undoStack.pop_back();
     delete s;
@@ -46,7 +46,7 @@ void GLLUTWidget::editRedo() {
     UndoState * s=redoStack.back();
     UndoState * r=new UndoState(_lut);
     s->restore(_lut);
-    for(int i=0; i<slices.size(); i++)
+    for(size_t i=0; i<slices.size(); i++)
       drawSlice(slices[i],_lut, i, false,true,false);
     redoStack.pop_back();
     delete s;

--- a/src/app/plugins/plugin_dvr.cpp
+++ b/src/app/plugins/plugin_dvr.cpp
@@ -364,7 +364,6 @@ void PluginDVR::slotMovieSave() {
         if (output.getNumBytes() > 0) {
           //write file:
           QString num = QString::number(i);
-          int n = max(5,num.length());
           num = "00000" + num;
           num = num.right(5);
           QString filename = dir + "/" + num + ".png";

--- a/src/app/plugins/plugin_legacypublishgeometry.cpp
+++ b/src/app/plugins/plugin_legacypublishgeometry.cpp
@@ -48,8 +48,8 @@ PluginLegacyPublishGeometry::PluginLegacyPublishGeometry(
     FrameBuffer* fb,
     RoboCupSSLServer* ds_udp_server_old,
     const RoboCupField& field) :
-    _ds_udp_server_old(ds_udp_server_old),
     VisionPlugin(fb),
+    _ds_udp_server_old(ds_udp_server_old),
     _field(field) {
   setSharedAmongStacks(true);
   _settings=new VarList("Publish Legacy Geometry");

--- a/src/app/stacks/multistack_robocup_ssl.cpp
+++ b/src/app/stacks/multistack_robocup_ssl.cpp
@@ -21,9 +21,9 @@
 #include "multistack_robocup_ssl.h"
 
 MultiStackRoboCupSSL::MultiStackRoboCupSSL(RenderOptions * _opts, int cameras) :
+    MultiVisionStack("RoboCup SSL Multi-Cam",_opts),
     ds_udp_server_new(NULL),
-    ds_udp_server_old(NULL),
-    MultiVisionStack("RoboCup SSL Multi-Cam",_opts) {
+    ds_udp_server_old(NULL) {
   //add global field calibration parameter
   global_field = new RoboCupField();
   settings->addChild(global_field->getSettings());

--- a/src/app/stacks/multivisionstack.cpp
+++ b/src/app/stacks/multivisionstack.cpp
@@ -28,7 +28,7 @@ MultiVisionStack::MultiVisionStack(string _name, RenderOptions * _opts) {
 
 MultiVisionStack::~MultiVisionStack() {
   stop();
-  for (int i=0;i<threads.size();i++) {
+  for (size_t i = 0; i < threads.size(); i++) {
     delete threads.at(i);
   }
   delete settings;

--- a/src/graphicalClient/gltext.cpp
+++ b/src/graphicalClient/gltext.cpp
@@ -295,6 +295,7 @@ const char* GLText::getPrimitiveType(GLenum type)
       return "GL_POLYGON";
       break;
   }
+  return "UNKNOWN";
 }
 
 void GLText::tessBeginCB(GLenum which)

--- a/src/graphicalClient/gltext.cpp
+++ b/src/graphicalClient/gltext.cpp
@@ -21,6 +21,9 @@
 
 #include "gltext.h"
 
+const bool GLText::debugTesselation = false;
+const double GLText::FontRenderSize = 1000.0;
+
 GLText::GLText(QFont _font)
 {
   glyphs.clear();

--- a/src/graphicalClient/gltext.h
+++ b/src/graphicalClient/gltext.h
@@ -45,7 +45,7 @@ class GLText{
   QVector<Glyph> glyphs;
   
   double characterSpacing;
-  static const bool debugTesselation = false;
+  static const bool debugTesselation;
   QFont font;
   
 public:
@@ -84,7 +84,7 @@ private:
   static void tessEndCB();
   static void tessVertexCB(const GLvoid *data);
   static void tessErrorCB(GLenum errorCode);
-  static const double FontRenderSize = 1000.0;
+  static const double FontRenderSize;
 };
 
 #endif //GL_TEXT_H

--- a/src/graphicalClient/soccerview.cpp
+++ b/src/graphicalClient/soccerview.cpp
@@ -29,6 +29,16 @@ using FieldConstantsRoboCup2014::kNumFieldArcs;
 using FieldConstantsRoboCup2014::kFieldLines;
 using FieldConstantsRoboCup2014::kFieldArcs;
 
+const double GLSoccerView::minZValue = -10;
+const double GLSoccerView::maxZValue = 10;
+const double GLSoccerView::FieldZ = 1.0;
+const double GLSoccerView::RobotZ = 2.0;
+const double GLSoccerView::BallZ = 3.0;
+const int GLSoccerView::PreferedWidth = 1024;
+const int GLSoccerView::PreferedHeight = 768;
+const double GLSoccerView::MinRedrawInterval = 0.016; ///Minimum time between graphics updates (limits the fps)
+const int GLSoccerView::unknownRobotID = -1;
+
 GLSoccerView::FieldDimensions::FieldDimensions() :
   field_length(FieldConstantsRoboCup2014::kFieldLength),
   field_width(FieldConstantsRoboCup2014::kFieldWidth),

--- a/src/graphicalClient/soccerview.cpp
+++ b/src/graphicalClient/soccerview.cpp
@@ -82,8 +82,6 @@ void GLSoccerView::mousePressEvent(QMouseEvent* event)
   leftButton = event->buttons().testFlag(Qt::LeftButton);
   midButton = event->buttons().testFlag(Qt::MidButton);
   rightButton = event->buttons().testFlag(Qt::RightButton);
-  bool shiftKey = event->modifiers().testFlag(Qt::ShiftModifier);
-  bool ctrlKey = event->modifiers().testFlag(Qt::ControlModifier);
 
   if(leftButton)
     setCursor(Qt::ClosedHandCursor);
@@ -99,8 +97,6 @@ void GLSoccerView::mousePressEvent(QMouseEvent* event)
 
 void GLSoccerView::mouseReleaseEvent(QMouseEvent* event)
 {
-  bool shiftKey = event->modifiers().testFlag(Qt::ShiftModifier);
-  bool ctrlKey = event->modifiers().testFlag(Qt::ControlModifier);
   setCursor(Qt::ArrowCursor);
 }
 
@@ -124,7 +120,6 @@ void GLSoccerView::mouseMoveEvent(QMouseEvent* event)
   }else if(midButton){
     //Zoom
     double zoomRatio = double(event->y() - mouseStartY)/500.0;
-    double oldScale = viewScale;
     viewScale = viewScale*(1.0+zoomRatio);
     recomputeProjection();
     mouseStartX = event->x();
@@ -137,7 +132,6 @@ void GLSoccerView::wheelEvent(QWheelEvent* event)
 {
   static const bool debug = false;
   double zoomRatio = -double(event->delta())/1000.0;
-  double oldScale = viewScale;
   viewScale = viewScale*(1.0+zoomRatio);
   recomputeProjection();
   if(debug) printf("Zoom: %5.3f\n",viewScale);
@@ -563,7 +557,7 @@ void GLSoccerView::updateFieldGeometry(const SSL_GeometryFieldSize& fieldSize) {
     delete fieldDim.lines[i];
   }
   fieldDim.lines.clear();
-  for (size_t i = 0; i < fieldSize.field_lines_size(); ++i) {
+  for (int i = 0; i < fieldSize.field_lines_size(); ++i) {
     const SSL_FieldLineSegment& line = fieldSize.field_lines(i);
     fieldDim.lines.push_back(new FieldLine(
         line.name(), line.p1().x(), line.p1().y(), 
@@ -573,7 +567,7 @@ void GLSoccerView::updateFieldGeometry(const SSL_GeometryFieldSize& fieldSize) {
     delete fieldDim.arcs[i];
   }
   fieldDim.arcs.clear();
-  for (size_t i = 0; i < fieldSize.field_arcs_size(); ++i) {
+  for (int i = 0; i < fieldSize.field_arcs_size(); ++i) {
     const SSL_FieldCicularArc& arc = fieldSize.field_arcs(i);
     fieldDim.arcs.push_back(new FieldCircularArc(
         arc.name(), arc.center().x(), arc.center().y(),  arc.radius(),

--- a/src/graphicalClient/soccerview.h
+++ b/src/graphicalClient/soccerview.h
@@ -74,15 +74,15 @@ public:
   }TeamTypes;
 
 private:
-  static const double minZValue = -10;
-  static const double maxZValue = 10;
-  static const double FieldZ = 1.0;
-  static const double RobotZ = 2.0;
-  static const double BallZ = 3.0;
-  static const int PreferedWidth = 1024;
-  static const int PreferedHeight = 768;
-  static const double MinRedrawInterval = 0.016; ///Minimum time between graphics updates (limits the fps)
-  static const int unknownRobotID = -1;
+  static const double minZValue;
+  static const double maxZValue;
+  static const double FieldZ;
+  static const double RobotZ;
+  static const double BallZ;
+  static const int PreferedWidth;
+  static const int PreferedHeight;
+  static const double MinRedrawInterval; ///Minimum time between graphics updates (limits the fps)
+  static const int unknownRobotID;
 
   QVector <QVector<Robot> > robots;
   QVector <QVector<vector2d> > balls;

--- a/src/logClient/ClientThreading.cpp
+++ b/src/logClient/ClientThreading.cpp
@@ -53,8 +53,6 @@ void ViewUpdateThread::run()
 
 int ViewUpdateThread::execute()
 {
-    int c = 0;
-    int n=0;
     Log_Frame* log_frame;
     SSL_DetectionFrame detection;
     if ( client.receive ( packet ) && !play)

--- a/src/logClient/GraphicsPrimitives.cpp
+++ b/src/logClient/GraphicsPrimitives.cpp
@@ -33,7 +33,7 @@ Robot::Robot()
   Robot ( 0,0,0,teamUnknown,0,0,0 );
 }
 
-Robot::Robot ( double _x, double _y, double _orientation, int _teamID, int _id, int _key, double _conf )
+Robot::Robot ( double _x, double _y, double _orientation, int _teamID, int _id, unsigned int _key, double _conf )
 {
   conf = _conf;
   key = _key;
@@ -195,7 +195,6 @@ void SoccerView::initView()
 
 void SoccerView::updateView()
 {
-  static float lastScale = 0;
   if ( shutdownSoccerView )
   {
     return;
@@ -291,7 +290,7 @@ void SoccerView::UpdateRobots ( SSL_DetectionFrame &detection )
     }
 
     double x,y,orientation,conf =robot.confidence();
-    int id=NA, n=0;
+    int id=NA;
     if ( robot.has_robot_id() )
       id = robot.robot_id();
     else

--- a/src/logClient/GraphicsPrimitives.h
+++ b/src/logClient/GraphicsPrimitives.h
@@ -51,7 +51,7 @@ class Robot : public QGraphicsPathItem
     int id;                 //ID of the robot in its team
     double x,y;
     double conf;
-    int key;
+    unsigned int key;
     QString robotLabel;
 
   private:
@@ -69,7 +69,7 @@ class Robot : public QGraphicsPathItem
     void update ( const QRectF & rect = QRectF() ) {return;}
 
     Robot();
-    Robot ( double _x, double _y, double _orientation, int _teamID, int _id, int _key, double _conf );
+    Robot ( double _x, double _y, double _orientation, int _teamID, int _id, unsigned int _key, double _conf );
     void SetPose ( double _x, double _y, double _orientation, double _conf );
     ~Robot();
 };

--- a/src/shared/capture/capture_generator.cpp
+++ b/src/shared/capture/capture_generator.cpp
@@ -138,7 +138,6 @@ RawImage CaptureGenerator::getFrame()
     int slice_width = w/n_colors;
     rgb color=RGB::Black;
     rgb color2;
-    int gradient=h/256;
     for (int x = 0 ; x < w; x++) {
       int c_idx= x/slice_width;
       if (c_idx==0) {

--- a/src/shared/capture/capturedc1394v2.cpp
+++ b/src/shared/capture/capturedc1394v2.cpp
@@ -730,13 +730,11 @@ void CaptureDC1394v2::readParameterProperty(VarList * item) {
       if (dc1394_feature_is_readable(camera,feature,&dcb) == DC1394_SUCCESS && dcb==true) {
         //get feature modes:
         bool has_manual_mode=false;
-        bool has_auto_mode=false;
         bool has_one_push=false;
         dc1394feature_modes_t all_modes;
         if (dc1394_feature_get_modes(camera, feature, &all_modes) == DC1394_SUCCESS) {
           for (unsigned int i = 0; i < all_modes.num ; i++) {
             if (all_modes.modes[i]==DC1394_FEATURE_MODE_MANUAL) has_manual_mode=true;
-            if (all_modes.modes[i]==DC1394_FEATURE_MODE_AUTO) has_auto_mode=true;
             if (all_modes.modes[i]==DC1394_FEATURE_MODE_ONE_PUSH_AUTO) has_one_push=true;
           }
         }

--- a/src/shared/capture/capturev4l.cpp
+++ b/src/shared/capture/capturev4l.cpp
@@ -806,7 +806,6 @@ void CaptureV4L::readParameterValues(VarList * item) {
 #ifndef VDATA_NO_QT
     mutex.lock();
 #endif
-    float fValue = 0.0;
     bool valid=true;
     v4lfeature_t feature=getV4LfeatureEnum(item,valid);
     if (valid==false) {
@@ -818,18 +817,12 @@ void CaptureV4L::readParameterValues(VarList * item) {
     }
     VarInt * vint=0;
     VarBool * venabled=0;
-    VarBool * vauto=0;
-    VarBool * vdefault=0;
     VarBool * vwasread=0;
-    
-    bool has_abs=false;
     
     vector<VarType *> children=item->getChildren();
     for (unsigned int i=0;i<children.size();i++) {
         if (children[i]->getType()==VARTYPE_ID_BOOL && children[i]->getName()=="was_read") vwasread=(VarBool *)children[i];
         if (children[i]->getType()==VARTYPE_ID_BOOL && children[i]->getName()=="enabled") venabled=(VarBool *)children[i];
-        if (children[i]->getType()==VARTYPE_ID_BOOL && children[i]->getName()=="default") vdefault=(VarBool *)children[i];
-        if (children[i]->getType()==VARTYPE_ID_BOOL && children[i]->getName()=="auto") vauto=(VarBool *)children[i];
         if (children[i]->getType()==VARTYPE_ID_INT && children[i]->getName()=="value") vint=(VarInt *)children[i];
     }
     
@@ -884,9 +877,7 @@ void CaptureV4L::writeParameterValues(VarList * item) {
         return;
     }
     VarInt * vint=0;
-    VarBool * vuseabs=0;
     VarBool * venabled=0;
-    VarBool * vauto=0;
     VarBool * vwasread=0;
     VarBool * vdefault=0;
     
@@ -894,8 +885,7 @@ void CaptureV4L::writeParameterValues(VarList * item) {
     for (unsigned int i=0;i<children.size();i++) {
         if (children[i]->getType()==VARTYPE_ID_BOOL && children[i]->getName()=="was_read") vwasread=(VarBool *)children[i];
         if (children[i]->getType()==VARTYPE_ID_BOOL && children[i]->getName()=="enabled") venabled=(VarBool *)children[i];
-        if (children[i]->getType()==VARTYPE_ID_BOOL && children[i]->getName()=="auto") vauto=(VarBool *)children[i];
-        if (children[i]->getType()==VARTYPE_ID_BOOL && children[i]->getName()=="default") vauto=(VarBool *)children[i];
+        if (children[i]->getType()==VARTYPE_ID_BOOL && children[i]->getName()=="default") vdefault=(VarBool *)children[i];
         if (children[i]->getType()==VARTYPE_ID_INT && children[i]->getName()=="value") vint=(VarInt *)children[i];
     }
     
@@ -939,23 +929,13 @@ void CaptureV4L::readParameterProperty(VarList * item) {
 #endif
         return;
     }
-    VarDouble * vabs=0;
     VarInt * vint=0;
-    VarBool * vuseabs=0;
     VarBool * venabled=0;
-    VarBool * vauto=0;
-    VarInt * vint2=0;
-    VarInt * vint3=0;
-    VarTrigger * vtrigger=0;
     
     vector<VarType *> children=item->getChildren();
     for (unsigned int i=0;i<children.size();i++) {
         if (children[i]->getType()==VARTYPE_ID_BOOL && children[i]->getName()=="enabled") venabled=(VarBool *)children[i];
-        if (children[i]->getType()==VARTYPE_ID_BOOL && children[i]->getName()=="auto") vauto=(VarBool *)children[i];
-        if (children[i]->getType()==VARTYPE_ID_BOOL && children[i]->getName()=="use absolute") vuseabs=(VarBool *)children[i];
         if (children[i]->getType()==VARTYPE_ID_INT && children[i]->getName()=="value") vint=(VarInt *)children[i];
-        if (children[i]->getType()==VARTYPE_ID_DOUBLE && children[i]->getName()=="absolute value") vabs=(VarDouble *)children[i];
-        if (children[i]->getType()==VARTYPE_ID_TRIGGER && children[i]->getName()=="one-push") vtrigger=(VarTrigger *)children[i];
     }
     
     long lDefault = 0;

--- a/src/shared/capture/capturev4l.h
+++ b/src/shared/capture/capturev4l.h
@@ -70,7 +70,7 @@ class GlobalV4LinstanceManager;
  */
 class GlobalV4Linstance
 {
-friend GlobalV4LinstanceManager;
+friend class GlobalV4LinstanceManager;
 public:
     struct image_t {
         unsigned char *data;
@@ -261,7 +261,7 @@ protected:
     VarStringEnum * v_format;
     VarInt    * v_buffer_size;
     
-    unsigned int cam_id;
+    int cam_id;
     int width;
     int height;
     int top;

--- a/src/shared/cmpattern/cmpattern_teamdetector.cpp
+++ b/src/shared/cmpattern/cmpattern_teamdetector.cpp
@@ -416,7 +416,7 @@ void TeamDetector::findRobotsByModel(::google::protobuf::RepeatedPtrField< ::SSL
   (void)image;
   const int MaxDetections = _other_markers_max_detections;
   Marker cen; // center marker
-  Marker markers[MaxDetections];
+  Marker *markers = new Marker[MaxDetections];
   const float marker_max_query_dist = _other_markers_max_query_distance;
   const float marker_max_dist = _pattern_max_dist;
 
@@ -506,6 +506,7 @@ void TeamDetector::findRobotsByModel(::google::protobuf::RepeatedPtrField< ::SSL
     robots->RemoveLast();
   }
 
+  delete markers;
 }
 
 

--- a/src/shared/cmpattern/cmpattern_teamdetector.cpp
+++ b/src/shared/cmpattern/cmpattern_teamdetector.cpp
@@ -506,7 +506,7 @@ void TeamDetector::findRobotsByModel(::google::protobuf::RepeatedPtrField< ::SSL
     robots->RemoveLast();
   }
 
-  delete markers;
+  delete[] markers;
 }
 
 

--- a/src/shared/cmpattern/cmpattern_teamdetector.h
+++ b/src/shared/cmpattern/cmpattern_teamdetector.h
@@ -40,14 +40,6 @@
 using namespace std;
 namespace CMPattern {
 
-class TeamDetectorInterface {
-public:
-  virtual VarList * getSettings() { return 0; };
-  virtual void update(::google::protobuf::RepeatedPtrField< ::SSL_DetectionRobot >* robots) { (void)robots; };
-  virtual ~TeamDetectorInterface() {};
-};
-
-
 class TeamDetector;
 class TeamSelector;
 
@@ -155,7 +147,7 @@ public:
 
 
 
-class TeamDetector : public TeamDetectorInterface {
+class TeamDetector {
 protected:
 
   //TeamDetectorSettings * _detector_settings;

--- a/src/shared/gl/glcamera.h
+++ b/src/shared/gl/glcamera.h
@@ -24,6 +24,7 @@
 #include "GL/gl.h"
 #include "globject.h"
 #include "geometry.h"
+#include <cmath>
 #ifndef NO_QT
   #include <QWheelEvent>
   #include <QKeyEvent>
@@ -141,7 +142,7 @@ public:
     vector3d d_forward = target.forward - forward;
     vector3d d_pos     = target.pos - pos;
     double   d_angle   = GVector::shortest_angle(rot.getZvector(),target.rot.getZvector());
-    if (isnan(d_angle)) d_angle=0.0;
+    if (std::isnan(d_angle)) d_angle=0.0;
     //compute spring forces:
 
     vector3d f_forward = d_forward * k_acc - v_forward * k_damp;
@@ -173,7 +174,7 @@ public:
     //perform angular blending:
     double blend_n=delta_angle / d_angle;
 
-    if (blend_n==0.0 || d_angle==0.0 || delta_angle==0.0 || isnan(blend_n)) {
+    if (blend_n==0.0 || d_angle==0.0 || delta_angle==0.0 || std::isnan(blend_n)) {
       //don't rotate!
     } else {
       rot.blend(blend_n,target.rot);

--- a/src/shared/util/field.cpp
+++ b/src/shared/util/field.cpp
@@ -423,7 +423,7 @@ void RoboCupField::ProcessNewFieldArcs() {
       }
     }
   }
-  if (field_arcs_list->getChildrenCount() != field_arcs.size()) {
+  if (static_cast<size_t>(field_arcs_list->getChildrenCount()) != field_arcs.size()) {
     fprintf(stderr, "Bug discovered, please report to the developers: "
             "field_arcs_list->getChildrenCount() != field_arcs.size(), @ "
             "%s:%d\n", __FILE__, __LINE__);
@@ -454,7 +454,7 @@ void RoboCupField::ProcessNewFieldLines() {
       }
     }
   }
-  if (field_lines_list->getChildrenCount() != field_lines.size()) {
+  if (static_cast<size_t>(field_lines_list->getChildrenCount()) != field_lines.size()) {
     fprintf(stderr, "Bug discovered, please report to the developers: "
             "field_lines_list->getChildrenCount() != field_lines.size(), @ "
             "%s:%d\n", __FILE__, __LINE__);
@@ -483,7 +483,7 @@ void RoboCupField::ResizeFieldLines() {
       field_lines_list->addChild(field_lines[i]->list);
     }
   }
-  if (field_lines_list->getChildrenCount() != field_lines.size()) {
+  if (static_cast<size_t>(field_lines_list->getChildrenCount()) != field_lines.size()) {
     fprintf(stderr, "Bug discovered, please report to the developers: "
             "field_lines_list->getChildrenCount() != field_lines.size(), @ "
             "%s:%d\n", __FILE__, __LINE__);
@@ -511,7 +511,7 @@ void RoboCupField::ResizeFieldArcs() {
       field_arcs_list->addChild(field_arcs[i]->list);
     }
   }
-  if (field_arcs_list->getChildrenCount() != field_arcs.size()) {
+  if (static_cast<size_t>(field_arcs_list->getChildrenCount()) != field_arcs.size()) {
     fprintf(stderr, "Bug discovered, please report to the developers: "
             "field_arcs_list->getChildrenCount() != field_arcs.size(), @ "
             "%s:%d\n", __FILE__, __LINE__);

--- a/src/shared/util/gvector.h
+++ b/src/shared/util/gvector.h
@@ -212,9 +212,9 @@ vector3d<num> cross(const vector3d<num> a,const vector3d<num> b)
   template <class num> \
   vector3d<num> &vector3d<num>::operator opr (const vector3d<num> p) \
   {                  \
-    x = x opr p.x;   \
-    y = y opr p.y;   \
-    z = z opr p.z;   \
+    x opr p.x;   \
+    y opr p.y;   \
+    z opr p.z;   \
     return(*this);   \
   }
 
@@ -257,9 +257,9 @@ VECTOR3D_SCALAR_OPERATOR(/)
   template <class num> \
   vector3d<num> &vector3d<num>::operator opr (num f) \
   {                \
-    x = x opr f;   \
-    y = y opr f;   \
-    z = z opr f;   \
+    x opr f;   \
+    y opr f;   \
+    z opr f;   \
     return(*this); \
   }
 
@@ -795,8 +795,8 @@ vector2d<num> vector2d<num>::project_out(const vector2d<num> p) const
   template <class num> \
   vector2d<num> &vector2d<num>::operator opr (const vector2d<num> p) \
   {                  \
-    x = x opr p.x;   \
-    y = y opr p.y;   \
+    x opr p.x;       \
+    y opr p.y;       \
     return(*this);   \
   }
 
@@ -837,8 +837,8 @@ VECTOR2D_SCALAR_OPERATOR(/)
   template <class num> \
   vector2d<num> &vector2d<num>::operator opr (num f) \
   {                \
-    x = x opr f;   \
-    y = y opr f;   \
+    x opr f;   \
+    y opr f;   \
     return(*this); \
   }
 

--- a/src/shared/util/image_io.cpp
+++ b/src/shared/util/image_io.cpp
@@ -386,10 +386,11 @@ bool ImageIO::writeRGB(rgb *imgbuf, int width, int height, const char *filename)
   QImageWriter writer;
   QString qfilename(filename);
   writer.setFileName(qfilename);
-  const char *ext = strrchr(filename,'.');
   return writer.write(img);
 
-/*  if(strcmp(ext,".ppm") == 0) return(ImageIO::writePPM (imgbuf,width,height,filename));
+/*
+  const char *ext = strrchr(filename,'.');
+  if(strcmp(ext,".ppm") == 0) return(ImageIO::writePPM (imgbuf,width,height,filename));
   if(strcmp(ext,".jpg") == 0) return(ImageIO::writeJPEG(imgbuf,width,height,filename,90));
   if(strcmp(ext,".png") == 0) return(ImageIO::WritePNG(imgbuf,width,height,filename));
 

--- a/src/shared/util/quaternion.h
+++ b/src/shared/util/quaternion.h
@@ -32,6 +32,7 @@
 */
 
 #include <iostream>
+#include <cmath>
 #include "gvector.h"
 #ifndef QUATERNION_H
 #define QUATERNION_H
@@ -362,7 +363,7 @@ static Quaternion<num> shortestArc( const GVector::vector3d<num> & from, const G
 
   cross /= dot ; //Get the x, y, z components
 
-  if (isnan(cross.x) || isnan(cross.y) || isnan(cross.z) || isnan(-dot/2)) {
+  if (std::isnan(cross.x) || std::isnan(cross.y) || std::isnan(cross.z) || std::isnan(-dot/2)) {
     printf("ERROR x: %f   y:%f   z: %f   w: %f\n",cross.x,cross.y,cross.z,-dot/2);
     fflush(stdout);
     exit(0);

--- a/src/shared/util/quaternion.h
+++ b/src/shared/util/quaternion.h
@@ -203,7 +203,7 @@ public:
       num sinAngle;
       angle *= 0.5f;
       GVector::vector3d<num> vn(v);
-      vn.norm();
+      vn.normalize();
 
       sinAngle = sin(angle);
 

--- a/src/shared/util/random.cpp
+++ b/src/shared/util/random.cpp
@@ -167,9 +167,9 @@ void Random::next_state()
   uint32_t *p=state;
   int j;
 
-  /* if init_genrand() has not been called, */
+  /* if seed() or randomize() has not been called, */
   /* a default initial seed is used         */
-  if(!left < 0) seed(5489UL);
+  if(left < 0) seed(5489UL);
 
   left = N;
   next = state;


### PR DESCRIPTION
This fixes all compiler warnings using g++ 5.2.1 (Ubuntu 15.10). Compiling should now also be possible using clang, but that results in a strange linker error for me (probably an incompatibility between g++ 5 and clang related to std::string).

Most changes are unsigned vs signed int, unused variables.

Special ones:
- Allocate marker array in _cmpattern_teamdetector.cpp_ using `new[]`. This allows compilation using clang
- Remove the TeamDetectorInterface from _cmpattern_teamdetector.h_. The interface is not used and defines an update function that differs from the one that's actually used.
- Used isnan from cmath in _glcamera.h_ .
- Fix operators in _gvector.h_ : `+=` would expand to `x = x += p.x;`. g++ complains about possibly undefined behavior. Replaced with `x += p.x`
- In _random.cpp_ : `if (!left < 0)` is always false according to clang. The correct implementation is probably `if (left < 0)