### PR TITLE
added high resolution timer from c++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 2.6)
 add_definitions(-D UNIX)
 add_definitions(-D LINUX)
 add_definitions(-D _GNU_SOURCE)
+add_definitions(-std=c++11 -fpermissive)
 
 SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 

--- a/src/shared/gl/glcamera.h
+++ b/src/shared/gl/glcamera.h
@@ -141,7 +141,7 @@ public:
     vector3d d_forward = target.forward - forward;
     vector3d d_pos     = target.pos - pos;
     double   d_angle   = GVector::shortest_angle(rot.getZvector(),target.rot.getZvector());
-    if (isnan(d_angle)) d_angle=0.0;
+    if (std::isnan(d_angle)) d_angle=0.0;
     //compute spring forces:
 
     vector3d f_forward = d_forward * k_acc - v_forward * k_damp;
@@ -173,7 +173,7 @@ public:
     //perform angular blending:
     double blend_n=delta_angle / d_angle;
 
-    if (blend_n==0.0 || d_angle==0.0 || delta_angle==0.0 || isnan(blend_n)) {
+    if (blend_n==0.0 || d_angle==0.0 || delta_angle==0.0 || std::isnan(blend_n)) {
       //don't rotate!
     } else {
       rot.blend(blend_n,target.rot);

--- a/src/shared/util/timer.h
+++ b/src/shared/util/timer.h
@@ -33,6 +33,8 @@
 #include <sys/time.h>
 #include <time.h>
 
+#include <ratio>
+#include <chrono>
 
 /*!
   \class Timer
@@ -161,9 +163,12 @@ inline double GetTimeSec()
   GetSystemTime(&time);
   return((double)time.seconds + time.useconds*(1.0E-6));
 #else
-  timeval tv;
-  gettimeofday(&tv,NULL);
-  return((double)tv.tv_sec + tv.tv_usec*(1.0E-6));
+  std::chrono::high_resolution_clock::time_point tStart;
+  return std::chrono::duration_cast<std::chrono::nanoseconds>
+   	  (std::chrono::high_resolution_clock::now() - tStart).count() / 1e9;
+//  timeval tv;
+//  gettimeofday(&tv,NULL);
+//  return((double)tv.tv_sec + tv.tv_usec*(1.0E-6));
 #endif
 }
 


### PR DESCRIPTION
A year or two ago, I applied this change to our vision and what to share it now.

Without this change, the timestamps I received from SSL vision in our AI software diverged from our internally tracked time (Java's System.nanotime() ). With the high resolution clock, time measurement is more precise.

The only drawback of this change is the use of C++11, but this should not be a problem anymore today...