### PR TITLE
Support for Matrix-Vision BlueFox2 cameras

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,19 @@ include_directories(${EIGEN3_INCLUDE_DIR})
 
 include ( ${QT_USE_FILE} )
 
-find_package(mvIMPACT REQUIRED)
-include_directories(${mvIMPACT_INCLUDE_DIRS})
+find_package(mvIMPACT QUIET)
 
 include(src/shared/CMakeLists.txt.inc)
+
+if(${mvIMPACT_FOUND} MATCHES "TRUE")
+  include_directories(${mvIMPACT_INCLUDE_DIRS})
+  add_definitions(-D MVIMPACT)
+  set (SHARED_SRCS ${SHARED_SRCS} ${shared_dir}/capture/capture_bluefox2.cpp)
+  set (SHARED_HEADERS ${SHARED_HEADERS} ${shared_dir}/capture/capture_bluefox2.h)
+  message(STATUS "mvIMPACT found => BlueFox2 support enabled")
+else()
+  message(STATUS "mvIMPACT NOT found => BlueFox2 support disabled")
+endif()
 
 include_directories(${PROJECT_SOURCE_DIR}/src/app)
 include_directories(${PROJECT_SOURCE_DIR}/src/app/gui)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ add_definitions(-D UNIX)
 add_definitions(-D LINUX)
 add_definitions(-D _GNU_SOURCE)
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
+
 SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 
 set (QT_USE_QTNETWORK true)
@@ -18,6 +20,9 @@ find_package( Eigen3 REQUIRED )
 include_directories(${EIGEN3_INCLUDE_DIR})
 
 include ( ${QT_USE_FILE} )
+
+find_package(mvIMPACT REQUIRED)
+include_directories(${mvIMPACT_INCLUDE_DIRS})
 
 include(src/shared/CMakeLists.txt.inc)
 
@@ -140,7 +145,7 @@ message (STATUS "Custom CC Flags: ${cc_flags}")
 
 add_definitions(${cc_flags})
 
-set (libs ${QT_LIBRARIES} ${EIGEN3_LIBRARIES} dc1394 jpeg png protobuf pthread GL GLU )
+set (libs ${QT_LIBRARIES} ${EIGEN3_LIBRARIES} ${mvIMPACT_LIBRARIES} dc1394 jpeg png protobuf pthread GL GLU )
 
 ## build the common code
 add_library(sslvision ${SHARED_MOC_SRCS} ${SHARED_RC_SRCS} ${CC_PROTO} ${SHARED_SRCS})
@@ -177,5 +182,3 @@ add_executable(${gclient} ${GCLIENT_MOC_SRCS}
   src/graphicalClient/gltext.cpp
 )
 target_link_libraries(${gclient} ${libs})
-
-

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To get all of these packages in (k)ubuntu, run:
 ## Hardware Requirements
  * The system supports 1394B / Firewire 800, but it's also backward compatible with 1394A.
  * The system also supports basic usb cameras via the [http://linuxtv.org/downloads/v4l-dvb-apis/](Video for Linux (V4L)) drivers. This implementation has only been tested on linux.
- * Matrix-Vision [BlueFox2](http://www.matrix-vision.com/USB2.0-single-board-camera-mvbluefox-mlc.html) cameras are supported via the mvIMPACT_acquire library. Tested with a mvBlueFOX-MLC200wC. To enable support for this camera please use the [install_mvBlueFox.sh](http://www.matrix-vision.com/USB2.0-single-board-camera-mvbluefox-mlc.html?file=tl_files/mv11/support/mvIMPACT_Acquire/01/install_mvBlueFOX.sh) script. The driver installation will be detected automatically during the build process.
+ * (Optional) Matrix-Vision [BlueFox2](http://www.matrix-vision.com/USB2.0-single-board-camera-mvbluefox-mlc.html) cameras are supported via the mvIMPACT_acquire library. Tested with a mvBlueFOX-MLC200wC. To enable support for this camera please use the [install_mvBlueFox.sh](http://www.matrix-vision.com/USB2.0-single-board-camera-mvbluefox-mlc.html?file=tl_files/mv11/support/mvIMPACT_Acquire/01/install_mvBlueFOX.sh) script. The library installation will be detected automatically during the build process. Support for this camera will be disabled silently if the library is not found.
 
 ## Compilation
  build the code by running:

--- a/README.md
+++ b/README.md
@@ -41,12 +41,14 @@
  * video for linux 2 (v4l)
 
 To get all of these packages in (k)ubuntu, run:
-sudo apt-get install g++ libqt4-dev libeigen3-dev protobuf-compiler libprotobuf-dev libdc1394-22 libdc1394-22-dev cmake libv4l-0
-
+```
+    sudo apt-get install g++ libqt4-dev libeigen3-dev protobuf-compiler libprotobuf-dev libdc1394-22 libdc1394-22-dev cmake libv4l-0
+```
 
 ## Hardware Requirements
  * The system supports 1394B / Firewire 800, but it's also backward compatible with 1394A.
  * The system also supports basic usb cameras via the [http://linuxtv.org/downloads/v4l-dvb-apis/](Video for Linux (V4L)) drivers. This implementation has only been tested on linux.
+ * Matrix-Vision [http://www.matrix-vision.com/USB2.0-single-board-camera-mvbluefox-mlc.html](BlueFox2) cameras are supported via the mvIMPACT_acquire library. Tested with a mvBlueFOX-MLC200wC. To enable support for this camera please use the [http://www.matrix-vision.com/USB2.0-single-board-camera-mvbluefox-mlc.html?file=tl_files/mv11/support/mvIMPACT_Acquire/01/install_mvBlueFOX.sh](install_mvBlueFox.sh) script. The driver installation will be detected automatically during the build process.
 
 ## Compilation
  build the code by running:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To get all of these packages in (k)ubuntu, run:
 ## Hardware Requirements
  * The system supports 1394B / Firewire 800, but it's also backward compatible with 1394A.
  * The system also supports basic usb cameras via the [http://linuxtv.org/downloads/v4l-dvb-apis/](Video for Linux (V4L)) drivers. This implementation has only been tested on linux.
- * Matrix-Vision [http://www.matrix-vision.com/USB2.0-single-board-camera-mvbluefox-mlc.html](BlueFox2) cameras are supported via the mvIMPACT_acquire library. Tested with a mvBlueFOX-MLC200wC. To enable support for this camera please use the [http://www.matrix-vision.com/USB2.0-single-board-camera-mvbluefox-mlc.html?file=tl_files/mv11/support/mvIMPACT_Acquire/01/install_mvBlueFOX.sh](install_mvBlueFox.sh) script. The driver installation will be detected automatically during the build process.
+ * Matrix-Vision [BlueFox2](http://www.matrix-vision.com/USB2.0-single-board-camera-mvbluefox-mlc.html) cameras are supported via the mvIMPACT_acquire library. Tested with a mvBlueFOX-MLC200wC. To enable support for this camera please use the [install_mvBlueFox.sh](http://www.matrix-vision.com/USB2.0-single-board-camera-mvbluefox-mlc.html?file=tl_files/mv11/support/mvIMPACT_Acquire/01/install_mvBlueFOX.sh) script. The driver installation will be detected automatically during the build process.
 
 ## Compilation
  build the code by running:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,13 @@ To get all of these packages in (k)ubuntu, run:
 ## Hardware Requirements
  * The system supports 1394B / Firewire 800, but it's also backward compatible with 1394A.
  * The system also supports basic usb cameras via the [http://linuxtv.org/downloads/v4l-dvb-apis/](Video for Linux (V4L)) drivers. This implementation has only been tested on linux.
- * (Optional) Matrix-Vision [BlueFox2](http://www.matrix-vision.com/USB2.0-single-board-camera-mvbluefox-mlc.html) cameras are supported via the mvIMPACT_acquire library. Tested with a mvBlueFOX-MLC200wC. To enable support for this camera please use the [install_mvBlueFox.sh](http://www.matrix-vision.com/USB2.0-single-board-camera-mvbluefox-mlc.html?file=tl_files/mv11/support/mvIMPACT_Acquire/01/install_mvBlueFOX.sh) script. The library installation will be detected automatically during the build process. Support for this camera will be disabled silently if the library is not found.
+
+### (Optional) Matrix-Vision [BlueFox2](http://www.matrix-vision.com/USB2.0-single-board-camera-mvbluefox-mlc.html)
+This camera type is supported via the mvIMPACT_acquire library. Tested with mvBlueFOX-MLC200wC. If the library is not found on your computer support for this camera will be disabled silently. To enable the BlueFox2 capture module please go to the Matrix-Vision [driver page](http://www.matrix-vision.com/software-drivers-en.html). Go to Linux => mvBlueFOX (USB2.0). Download the install_mvBlueFOX script and the correct .tgz file for your machine. Open a terminal and navigate to your download folder. For a quick installation run:
+```
+chmod +x install_mvBlueFOX.sh
+./install_mvBlueFOX.sh -u
+```
 
 ## Compilation
  build the code by running:

--- a/cmake/FindmvIMPACT.cmake
+++ b/cmake/FindmvIMPACT.cmake
@@ -58,8 +58,10 @@ macro(mvIMPACT_REPORT_NOT_FOUND REASON_MSG)
     else()
         # Neither QUIETLY nor REQUIRED, use no priority which emits a message
         # but continues configuration and allows generation.
-        message("-- Failed to find mvimpact - " ${REASON_MSG} ${ARGN})
+#        message("-- Failed to find mvimpact - " ${REASON_MSG} ${ARGN})
     endif()
+    
+    return()
 endmacro(mvIMPACT_REPORT_NOT_FOUND)
 
 # Search user-installed locations first, so that we prefer user installs
@@ -94,7 +96,7 @@ if(NOT mvIMPACT_INCLUDE_DIR OR NOT EXISTS ${mvIMPACT_INCLUDE_DIR})
         "path to mvimpact include directory,"
         "e.g. /opt/mvIMPACT_acquire.")
 else()
-    message(STATUS "mvimpact include dir found: " ${mvIMPACT_INCLUDE_DIR})
+#    message(STATUS "mvimpact include dir found: " ${mvIMPACT_INCLUDE_DIR})
 endif()
 
 # Find library directory for mvimpact
@@ -110,7 +112,7 @@ if(NOT mvIMPACT_LIBRARY OR NOT EXISTS ${mvIMPACT_LIBRARY})
 else()
     # TODO: need to fix this hacky solution for getting mvIMPACT_LIBRARY_DIR
     string(REGEX MATCH ".*/" mvIMPACT_LIBRARY_DIR ${mvIMPACT_LIBRARY})
-    message(STATUS "mvimpact library dir found: " ${mvIMPACT_LIBRARY_DIR})
+#    message(STATUS "mvimpact library dir found: " ${mvIMPACT_LIBRARY_DIR})
 endif()
 
 # Mark internally as found, then verify. mvIMPACT_REPORT_NOT_FOUND() unsets if

--- a/cmake/FindmvIMPACT.cmake
+++ b/cmake/FindmvIMPACT.cmake
@@ -1,0 +1,157 @@
+# FindmvIMPACT.cmake - Find mvIMPACT sdk, version >= 4.
+# Modified from FindEigen.cmake by alexs.mac@gmail.com  (Alex Stewart)
+#
+# This module defines the following variables:
+#
+# mvIMPACT_FOUND: TRUE if mvimpact is found.
+# mvIMPACT_INCLUDE_DIRS: Include directories for mvimpact.
+# mvIMPACT_LIBRARIES: Libraries for all mvimpact component libraries and
+#                     dependencies.
+#
+# mvIMPACT_VERSION: Extracted from lib/libmvBlueFOX .so.x.y.z
+# mvIMPACT_WORLD_VERSION: Equal to 4 if mvIMPACT_VERSION = 4.0.5
+# mvIMPACT_MAJOR_VERSION: Equal to 0 if mvIMPACT_VERSION = 4.0.5
+# mvIMPACT_MINOR_VERSION: Equal to 5 if mvIMPACT_VERSION = 4.0.5
+#
+# The following variables control the behaviour of this module:
+#
+# mvIMPACT_INCLUDE_DIR_HINTS: List of additional directories in which to
+#                             search for mvimpact includes, e.g: /foo/include.
+# mvIMPACT_LIBRARY_DIR_HINTS: List of additional directories in which to
+#                             search for mvimpact libraries, e.g: /bar/lib.
+#
+# The following variables are also defined by this module, but in line with
+# CMake recommended FindPackage() module style should NOT be referenced directly
+# by callers (use the plural variables detailed above instead).  These variables
+# do however affect the behaviour of the module via FIND_[PATH/LIBRARY]() which
+# are NOT re-called (i.e. search for library is not repeated) if these variables
+# are set with valid values _in the CMake cache_. This means that if these
+# variables are set directly in the cache, either by the user in the CMake GUI,
+# or by the user passing -DVAR=VALUE directives to CMake when called (which
+# explicitly defines a cache variable), then they will be used verbatim,
+# bypassing the HINTS variables and other hard-coded search locations.
+#
+# mvIMPACT_INCLUDE_DIR: Include directory for mvimpact, not including the
+#                       include directory of any dependencies.
+# mvIMPACT_LIBRARY: mvimpact library, not including the libraries of any
+#                   dependencies.
+
+# Called if we failed to find mvimpact or any of it's required dependencies,
+# unsets all public (designed to be used externally) variables and reports
+# error message at priority depending upon [REQUIRED/QUIET/<NONE>] argument.
+macro(mvIMPACT_REPORT_NOT_FOUND REASON_MSG)
+    unset(mvIMPACT_FOUND)
+    unset(mvIMPACT_INCLUDE_DIRS)
+    unset(mvIMPACT_LIBRARIES)
+    unset(mvIMPACT_WORLD_VERSION)
+    unset(mvIMPACT_MAJOR_VERSION)
+    unset(mvIMPACT_MINOR_VERSION)
+    # Make results of search visible in the CMake GUI if mvimpact has not
+    # been found so that user does not have to toggle to advanced view.
+    mark_as_advanced(CLEAR mvIMPACT_INCLUDE_DIR)
+    # Note <package>_FIND_[REQUIRED/QUIETLY] variables defined by FindPackage()
+    # use the camelcase library name, not uppercase.
+    if(Mvimpact_FIND_QUIETLY)
+        message(STATUS "Failed to find mvimpact - " ${REASON_MSG} ${ARGN})
+    elseif(Mvimpact_FIND_REQUIRED)
+        message(FATAL_ERROR "Failed to find mvimpact - " ${REASON_MSG} ${ARGN})
+    else()
+        # Neither QUIETLY nor REQUIRED, use no priority which emits a message
+        # but continues configuration and allows generation.
+        message("-- Failed to find mvimpact - " ${REASON_MSG} ${ARGN})
+    endif()
+endmacro(mvIMPACT_REPORT_NOT_FOUND)
+
+# Search user-installed locations first, so that we prefer user installs
+# to system installs where both exist.
+get_filename_component(BLUEFOX2_DIR ${CMAKE_CURRENT_SOURCE_DIR} REALPATH)
+list(APPEND mvIMPACT_CHECK_INCLUDE_DIRS
+    /opt/mvIMPACT_acquire
+    ${BLUEFOX2_DIR}/mvIMPACT/include
+    )
+execute_process(COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCH)
+list(APPEND mvIMPACT_CHECK_LIBRARY_DIRS
+    /opt/mvIMPACT_acquire/lib/${ARCH}
+    ${BLUEFOX2_DIR}/mvIMPACT/lib/${ARCH}
+    )
+
+# Check general hints
+if(mvIMPACT_HINTS AND EXISTS ${mvIMPACT_HINTS})
+    set(mvIMPACT_INCLUDE_DIR_HINTS ${mvIMPACT_HINTS}/include)
+    set(mvIMPACT_LIBRARY_DIR_HINTS ${mvIMPACT_HINTS}/lib)
+endif()
+
+# Search supplied hint directories first if supplied.
+# Find include directory for mvimpact
+find_path(mvIMPACT_INCLUDE_DIR
+    NAMES mvIMPACT_CPP/mvIMPACT_acquire.h
+    PATHS ${mvIMPACT_INCLUDE_DIR_HINTS}
+    ${mvIMPACT_CHECK_INCLUDE_DIRS}
+    NO_DEFAULT_PATH)
+if(NOT mvIMPACT_INCLUDE_DIR OR NOT EXISTS ${mvIMPACT_INCLUDE_DIR})
+    mvIMPACT_REPORT_NOT_FOUND(
+        "Could not find mvimpact include directory, set mvIMPACT_INCLUDE_DIR to "
+        "path to mvimpact include directory,"
+        "e.g. /opt/mvIMPACT_acquire.")
+else()
+    message(STATUS "mvimpact include dir found: " ${mvIMPACT_INCLUDE_DIR})
+endif()
+
+# Find library directory for mvimpact
+find_library(mvIMPACT_LIBRARY
+    NAMES libmvBlueFOX.so
+    PATHS ${mvIMPACT_LIBRARY_DIR_HINTS}
+    ${mvIMPACT_CHECK_LIBRARY_DIRS}
+    NO_DEFAULT_PATH)
+if(NOT mvIMPACT_LIBRARY OR NOT EXISTS ${mvIMPACT_LIBRARY})
+    mvIMPACT_REPORT_NOT_FOUND(
+        "Could not find mvimpact library, set mvIMPACT_LIBRARY "
+        "to full path to mvimpact library direcotory.")
+else()
+    # TODO: need to fix this hacky solution for getting mvIMPACT_LIBRARY_DIR
+    string(REGEX MATCH ".*/" mvIMPACT_LIBRARY_DIR ${mvIMPACT_LIBRARY})
+    message(STATUS "mvimpact library dir found: " ${mvIMPACT_LIBRARY_DIR})
+endif()
+
+# Mark internally as found, then verify. mvIMPACT_REPORT_NOT_FOUND() unsets if
+# called.
+set(mvIMPACT_FOUND TRUE)
+
+# Extract mvimpact version
+if(mvIMPACT_LIBRARY_DIR)
+    file(GLOB mvIMPACT_LIBS
+        RELATIVE ${mvIMPACT_LIBRARY_DIR}
+        ${mvIMPACT_LIBRARY_DIR}/libmvBlueFOX.so.[0-9].[0-9].[0-9])
+    # TODO: add version support
+    # string(REGEX MATCH ""
+    #       mvIMPACT_WORLD_VERSION ${mvIMPACT_PVBASE})
+    # message(STATUS "mvimpact world version: " ${mvIMPACT_WORLD_VERSION})
+endif()
+
+# Catch case when caller has set mvIMPACT_INCLUDE_DIR in the cache / GUI and
+# thus FIND_[PATH/LIBRARY] are not called, but specified locations are
+# invalid, otherwise we would report the library as found.
+if(mvIMPACT_INCLUDE_DIR AND NOT EXISTS ${mvIMPACT_INCLUDE_DIR}/mvIMPACT_CPP/mvIMPACT_acquire.h)
+    mvIMPACT_REPORT_NOT_FOUND("Caller defined mvIMPACT_INCLUDE_DIR: "
+        ${mvIMPACT_INCLUDE_DIR}
+        " does not contain mvIMPACT_CPP/mvIMPACT_acquire.h header.")
+endif()
+
+# Set standard CMake FindPackage variables if found.
+if(mvIMPACT_FOUND)
+    set(mvIMPACT_INCLUDE_DIRS ${mvIMPACT_INCLUDE_DIR})
+    file(GLOB mvIMPACT_LIBRARIES ${mvIMPACT_LIBRARY_DIR}libmvBlue*.so ${mvIMPACT_LIBRARY_DIR}libmvDev*.so)
+endif()
+
+# Handle REQUIRED / QUIET optional arguments.
+include(FindPackageHandleStandardArgs)
+if(mvIMPACT_FOUND)
+    FIND_PACKAGE_HANDLE_STANDARD_ARGS(Mvimpact DEFAULT_MSG
+        mvIMPACT_INCLUDE_DIRS mvIMPACT_LIBRARIES)
+endif()
+
+# Only mark internal variables as advanced if we found mvimpact, otherwise
+# leave it visible in the standard GUI for the user to set manually.
+if(mvIMPACT_FOUND)
+    mark_as_advanced(FORCE mvIMPACT_INCLUDE_DIR mvIMPACT_LIBRARY)
+endif()

--- a/src/app/capture_thread.cpp
+++ b/src/app/capture_thread.cpp
@@ -37,10 +37,12 @@ CaptureThread::CaptureThread(int cam_id)
   captureModule->addFlags(VARTYPE_FLAG_NOLOAD_ENUM_CHILDREN);
   captureModule->addItem("DC 1394");
   captureModule->addItem("Video 4 Linux");
+  captureModule->addItem("BlueFox2");
   captureModule->addItem("Read from files");
   captureModule->addItem("Generator");
   settings->addChild( (VarType*) (dc1394 = new VarList("DC1394")));
   settings->addChild( (VarType*) (v4l = new VarList("Video 4 Linux")));
+  settings->addChild( (VarType*) (bluefox2 = new VarList("BlueFox2")));
   settings->addChild( (VarType*) (fromfile = new VarList("Read from files")));
   settings->addChild( (VarType*) (generator = new VarList("Generator")));
   settings->addFlags( VARTYPE_FLAG_AUTO_EXPAND_TREE );
@@ -58,6 +60,7 @@ CaptureThread::CaptureThread(int cam_id)
   captureFiles = new CaptureFromFile(fromfile);
   captureGenerator = new CaptureGenerator(generator);
   captureV4L = new CaptureV4L(v4l,camId);
+  captureBlueFox2 = new CaptureBlueFox2(bluefox2,camId);
   selectCaptureMethod();
   _kill =false;
   rb=0;
@@ -81,6 +84,7 @@ CaptureThread::~CaptureThread()
 {
   delete captureDC1394;
   delete captureV4L;
+  delete captureBlueFox2;
   delete captureFiles;
   delete captureGenerator;
   delete counter;
@@ -108,8 +112,10 @@ void CaptureThread::selectCaptureMethod() {
     new_capture = captureGenerator;
   } else if(captureModule->getString() == "DC 1394") {
     new_capture = captureDC1394;
-  } else {
+  } else if(captureModule->getString() == "Video 4 Linux") {
     new_capture = captureV4L;
+  } else {
+    new_capture = captureBlueFox2;
   }
 
   if (old_capture!=0 && new_capture!=old_capture && old_capture->isCapturing()) {

--- a/src/app/capture_thread.cpp
+++ b/src/app/capture_thread.cpp
@@ -123,7 +123,7 @@ void CaptureThread::selectCaptureMethod() {
 #endif
   } else if(captureModule->getString() == "Video 4 Linux") {
     new_capture = captureV4L;
-  } else {
+  } else if(captureModule->getString() == "DC 1394") {
     new_capture = captureDC1394;
   }
 

--- a/src/app/capture_thread.cpp
+++ b/src/app/capture_thread.cpp
@@ -37,12 +37,10 @@ CaptureThread::CaptureThread(int cam_id)
   captureModule->addFlags(VARTYPE_FLAG_NOLOAD_ENUM_CHILDREN);
   captureModule->addItem("DC 1394");
   captureModule->addItem("Video 4 Linux");
-  captureModule->addItem("BlueFox2");
   captureModule->addItem("Read from files");
   captureModule->addItem("Generator");
   settings->addChild( (VarType*) (dc1394 = new VarList("DC1394")));
   settings->addChild( (VarType*) (v4l = new VarList("Video 4 Linux")));
-  settings->addChild( (VarType*) (bluefox2 = new VarList("BlueFox2")));
   settings->addChild( (VarType*) (fromfile = new VarList("Read from files")));
   settings->addChild( (VarType*) (generator = new VarList("Generator")));
   settings->addFlags( VARTYPE_FLAG_AUTO_EXPAND_TREE );
@@ -60,7 +58,13 @@ CaptureThread::CaptureThread(int cam_id)
   captureFiles = new CaptureFromFile(fromfile);
   captureGenerator = new CaptureGenerator(generator);
   captureV4L = new CaptureV4L(v4l,camId);
+  
+#ifdef MVIMPACT
+  captureModule->addItem("BlueFox2");
+  settings->addChild( (VarType*) (bluefox2 = new VarList("BlueFox2")));
   captureBlueFox2 = new CaptureBlueFox2(bluefox2,camId);
+#endif
+  
   selectCaptureMethod();
   _kill =false;
   rb=0;
@@ -84,10 +88,13 @@ CaptureThread::~CaptureThread()
 {
   delete captureDC1394;
   delete captureV4L;
-  delete captureBlueFox2;
   delete captureFiles;
   delete captureGenerator;
   delete counter;
+  
+#ifdef MVIMPACT
+  delete captureBlueFox2;
+#endif
 }
 
 void CaptureThread::setFrameBuffer(FrameBuffer * _rb) {
@@ -110,12 +117,14 @@ void CaptureThread::selectCaptureMethod() {
     new_capture = captureFiles;
   } else if(captureModule->getString() == "Generator") {
     new_capture = captureGenerator;
-  } else if(captureModule->getString() == "DC 1394") {
-    new_capture = captureDC1394;
+#ifdef MVIMPACT
+  } else if(captureModule->getString() == "BlueFox2") {
+    new_capture = captureBlueFox2;
+#endif
   } else if(captureModule->getString() == "Video 4 Linux") {
     new_capture = captureV4L;
   } else {
-    new_capture = captureBlueFox2;
+    new_capture = captureDC1394;
   }
 
   if (old_capture!=0 && new_capture!=old_capture && old_capture->isCapturing()) {

--- a/src/app/capture_thread.h
+++ b/src/app/capture_thread.h
@@ -24,6 +24,7 @@
 #include "capturedc1394v2.h"
 #include "capturefromfile.h"
 #include "capturev4l.h"
+#include "capture_bluefox2.h"
 #include "capture_generator.h"
 #include <QThread>
 #include "ringbuffer.h"
@@ -49,6 +50,7 @@ protected:
   CaptureInterface * capture;
   CaptureInterface * captureDC1394;
   CaptureInterface * captureV4L;
+  CaptureInterface * captureBlueFox2;
   CaptureInterface * captureFiles;
   CaptureInterface * captureGenerator;
   AffinityManager * affinity;
@@ -58,6 +60,7 @@ protected:
   VarList * settings;
   VarList * dc1394;
   VarList * v4l;
+  VarList * bluefox2;
   VarList * generator;
   VarList * fromfile;
   VarList * control;

--- a/src/app/capture_thread.h
+++ b/src/app/capture_thread.h
@@ -24,7 +24,6 @@
 #include "capturedc1394v2.h"
 #include "capturefromfile.h"
 #include "capturev4l.h"
-#include "capture_bluefox2.h"
 #include "capture_generator.h"
 #include <QThread>
 #include "ringbuffer.h"
@@ -33,6 +32,10 @@
 #include "visionstack.h"
 #include "capturestats.h"
 #include "affinity_manager.h"
+
+#ifdef MVIMPACT
+#include "capture_bluefox2.h"
+#endif
 
 /*!
   \class   CaptureThread

--- a/src/shared/CMakeLists.txt.inc
+++ b/src/shared/CMakeLists.txt.inc
@@ -15,6 +15,7 @@ include_directories(${shared_dir}/vartypes/xml)
 set (SHARED_SRCS
 	${shared_dir}/capture/capturedc1394v2.cpp
 	${shared_dir}/capture/capturev4l.cpp
+	${shared_dir}/capture/capture_bluefox2.cpp
 	${shared_dir}/capture/capturefromfile.cpp
   ${shared_dir}/capture/capture_generator.cpp
 	${shared_dir}/capture/captureinterface.cpp
@@ -102,6 +103,7 @@ set (SHARED_SRCS
 set (SHARED_HEADERS
 	${shared_dir}/capture/capturedc1394v2.h
 	${shared_dir}/capture/capturev4l.h
+	${shared_dir}/capture/capture_bluefox2.h
 	${shared_dir}/capture/capturefromfile.h
   ${shared_dir}/capture/capture_generator.h
 

--- a/src/shared/CMakeLists.txt.inc
+++ b/src/shared/CMakeLists.txt.inc
@@ -15,9 +15,8 @@ include_directories(${shared_dir}/vartypes/xml)
 set (SHARED_SRCS
 	${shared_dir}/capture/capturedc1394v2.cpp
 	${shared_dir}/capture/capturev4l.cpp
-	${shared_dir}/capture/capture_bluefox2.cpp
 	${shared_dir}/capture/capturefromfile.cpp
-  ${shared_dir}/capture/capture_generator.cpp
+	${shared_dir}/capture/capture_generator.cpp
 	${shared_dir}/capture/captureinterface.cpp
 
 	${shared_dir}/cmpattern/cmpattern_pattern.cpp
@@ -103,7 +102,6 @@ set (SHARED_SRCS
 set (SHARED_HEADERS
 	${shared_dir}/capture/capturedc1394v2.h
 	${shared_dir}/capture/capturev4l.h
-	${shared_dir}/capture/capture_bluefox2.h
 	${shared_dir}/capture/capturefromfile.h
   ${shared_dir}/capture/capture_generator.h
 

--- a/src/shared/capture/capture_bluefox2.cpp
+++ b/src/shared/capture/capture_bluefox2.cpp
@@ -47,7 +47,7 @@ CaptureBlueFox2::CaptureBlueFox2(VarList * _settings,int default_camera_id) : Ca
   dcam_parameters->addFlags( VARTYPE_FLAG_HIDE_CHILDREN );
 
   v_expose_us = new VarInt("Expose [us]", 2000, 10, 100000);
-  v_expose_overlapped = new VarBool("Expose Overlapped", false);
+  v_expose_overlapped = new VarBool("Expose Overlapped", true);
   v_gain_db = new VarDouble("Gain [dB]", 0.0, 0.0, 12.0);
   
   v_hdr_mode = new VarStringEnum("HDR Mode", hdrModeToString(HDR_MODE_OFF));
@@ -265,7 +265,8 @@ void CaptureBlueFox2::writeParameterValues(VarList * item)
 
 CaptureBlueFox2::~CaptureBlueFox2()
 {
-  //FIXME: delete all of dcam_parameters children
+  capture_settings->deleteAllChildren();
+  dcam_parameters->deleteAllChildren();
 }
 
 bool CaptureBlueFox2::resetBus()
@@ -286,6 +287,10 @@ bool CaptureBlueFox2::stopCapture()
   if (isCapturing())
   {
     readAllParameterValues();
+    
+    delete pFI;
+    delete pSettings;
+    delete pImageProc;
     
     pDevice->close();
     
@@ -347,12 +352,6 @@ bool CaptureBlueFox2::startCapture()
   
   ImageDestination id( pDevice );
   id.restoreDefault();
-  unsigned int pixelFormats = id.pixelFormat.dictSize();
-    // display all available pixel formats and there numerical representation.
-  for( unsigned int i = 0; i < pixelFormats; i++ )
-  {
-      fprintf(stderr, "[%d]: %s\n", id.pixelFormat.getTranslationDictValue( i ), id.pixelFormat.getTranslationDictString( i ).c_str());
-  }
   
   ColorFormat out_color = Colors::stringToColorFormat(v_colorout->getSelection().c_str());
   if(out_color == COLOR_RGB8)

--- a/src/shared/capture/capture_bluefox2.cpp
+++ b/src/shared/capture/capture_bluefox2.cpp
@@ -399,6 +399,8 @@ bool CaptureBlueFox2::startCapture()
   printf("BlueFox2 Info: Restoring Previously Saved Camera Parameters\n");
   writeAllParameterValues();
   readAllParameterValues();
+  
+  return true;
 }
 
 bool CaptureBlueFox2::copyAndConvertFrame(const RawImage & src, RawImage & target)
@@ -426,7 +428,7 @@ bool CaptureBlueFox2::copyAndConvertFrame(const RawImage & src, RawImage & targe
   }
   else
   {
-    for(unsigned int i = 0; i < src.getNumBytes(); i += 2)
+    for(int i = 0; i < src.getNumBytes(); i += 2)
     {
       target.getData()[i+1] = src.getData()[i];
       target.getData()[i] = src.getData()[i+1];

--- a/src/shared/capture/capture_bluefox2.cpp
+++ b/src/shared/capture/capture_bluefox2.cpp
@@ -80,10 +80,22 @@ CaptureBlueFox2::CaptureBlueFox2(VarList * _settings,int default_camera_id) : Ca
   v_aoi_left = new VarInt("AOI left", 0, 0, 752);
   v_aoi_top = new VarInt("AOI top", 0, 0, 480);
   
+  v_pixel_clock = new VarStringEnum("Pixel Clock", pixelClockToString(cpc40000KHz));
+  v_pixel_clock->addItem(pixelClockToString(cpc6000KHz));
+  v_pixel_clock->addItem(pixelClockToString(cpc8000KHz));
+  v_pixel_clock->addItem(pixelClockToString(cpc10000KHz));
+  v_pixel_clock->addItem(pixelClockToString(cpc12000KHz));
+  v_pixel_clock->addItem(pixelClockToString(cpc20000KHz));
+  v_pixel_clock->addItem(pixelClockToString(cpc24000KHz));
+  v_pixel_clock->addItem(pixelClockToString(cpc27000KHz));
+  v_pixel_clock->addItem(pixelClockToString(cpc32000KHz));
+  v_pixel_clock->addItem(pixelClockToString(cpc40000KHz));
+  
   dcam_parameters->addChild(v_aoi_width);
   dcam_parameters->addChild(v_aoi_height);
   dcam_parameters->addChild(v_aoi_left);
   dcam_parameters->addChild(v_aoi_top);
+  dcam_parameters->addChild(v_pixel_clock);
   dcam_parameters->addChild(v_expose_us);
   dcam_parameters->addChild(v_expose_overlapped);
   dcam_parameters->addChild(v_gain_db);
@@ -159,7 +171,9 @@ void CaptureBlueFox2::writeParameterValues(VarList * item)
   #ifndef VDATA_NO_QT
     mutex.lock();
   #endif
-  
+    
+  pSettings->pixelClock_KHz.write(stringToPixelClock(v_pixel_clock->getString().c_str()));
+
   pSettings->expose_us.write(v_expose_us->getInt());
   
   if(v_expose_overlapped->getBool())
@@ -365,7 +379,6 @@ bool CaptureBlueFox2::startCapture()
   
   pSettings = new CameraSettingsBlueFOX(pDevice);
   pSettings->restoreDefault();
-  pSettings->pixelClock_KHz.write(cpc40000KHz);
   
   pImageProc = new ImageProcessing(pDevice);
   pImageProc->restoreDefault();

--- a/src/shared/capture/capture_bluefox2.cpp
+++ b/src/shared/capture/capture_bluefox2.cpp
@@ -1,0 +1,507 @@
+//========================================================================
+//  This software is free: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License Version 3,
+//  as published by the Free Software Foundation.
+//
+//  This software is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  Version 3 in the file COPYING that came with this distribution.
+//  If not, see <http://www.gnu.org/licenses/>.
+//========================================================================
+/*!
+  \file    capture_bluefox2.cpp
+  \brief   C++ Implementation: CaptureBlueFox2
+  \author  Andre Ryll, (C) 2016
+*/
+//========================================================================
+
+#include "capture_bluefox2.h"
+
+#ifndef VDATA_NO_QT
+CaptureBlueFox2::CaptureBlueFox2(VarList * _settings,int default_camera_id, QObject * parent) : QObject(parent), CaptureInterface(_settings)
+#else
+CaptureBlueFox2::CaptureBlueFox2(VarList * _settings,int default_camera_id) : CaptureInterface(_settings)
+#endif
+{
+  cam_id = default_camera_id;
+  is_capturing = false;
+  
+  #ifndef VDATA_NO_QT
+    mutex.lock();
+  #endif
+
+  settings->addChild(capture_settings = new VarList("Capture Settings"));
+  settings->addChild(dcam_parameters  = new VarList("Camera Parameters"));
+
+  //=======================CAPTURE SETTINGS==========================
+  capture_settings->addChild(v_cam_bus          = new VarInt("cam idx",default_camera_id));
+  capture_settings->addChild(v_colorout         = new VarStringEnum("color mode", Colors::colorFormatToString(COLOR_YUV422_UYVY)));
+  v_colorout->addItem(Colors::colorFormatToString(COLOR_YUV422_UYVY));
+  v_colorout->addItem(Colors::colorFormatToString(COLOR_RGB8));
+
+  //=======================DCAM PARAMETERS===========================
+  dcam_parameters->addFlags( VARTYPE_FLAG_HIDE_CHILDREN );
+
+  v_expose_us = new VarInt("Expose [us]", 2000, 10, 100000);
+  v_expose_overlapped = new VarBool("Expose Overlapped", false);
+  v_gain_db = new VarDouble("Gain [dB]", 0.0, 0.0, 12.0);
+  
+  v_hdr_mode = new VarStringEnum("HDR Mode", hdrModeToString(HDR_MODE_OFF));
+  v_hdr_mode->addItem(hdrModeToString(HDR_MODE_OFF));
+  v_hdr_mode->addItem(hdrModeToString(HDR_MODE_FIXED0));
+  v_hdr_mode->addItem(hdrModeToString(HDR_MODE_FIXED1));
+  v_hdr_mode->addItem(hdrModeToString(HDR_MODE_FIXED2));
+  v_hdr_mode->addItem(hdrModeToString(HDR_MODE_FIXED3));
+  v_hdr_mode->addItem(hdrModeToString(HDR_MODE_FIXED4));
+  v_hdr_mode->addItem(hdrModeToString(HDR_MODE_FIXED5));
+  
+  v_mirror_top_down = new VarBool("Mirror Top/Down");
+  v_mirror_left_right = new VarBool("Mirror Left/Right");
+  v_wb_red = new VarDouble("WB Red", 1.0, 0.1, 10.0);
+  v_wb_green = new VarDouble("WB Green", 1.0, 0.1, 10.0);
+  v_wb_blue = new VarDouble("WB Blue", 1.0, 0.1, 10.0);
+  v_sharpen = new VarBool("Sharpen", true);
+  v_gamma = new VarDouble("Gamma", 1.0, 0.01, 10.0);
+  
+  v_color_twist_mode = new VarStringEnum("Color Twist", colorTwistModeToString(COLOR_TWIST_MODE_SRGB_D50));
+  v_color_twist_mode->addItem(colorTwistModeToString(COLOR_TWIST_MODE_OFF));
+  v_color_twist_mode->addItem(colorTwistModeToString(COLOR_TWIST_MODE_ADOBERGB_D50));
+  v_color_twist_mode->addItem(colorTwistModeToString(COLOR_TWIST_MODE_SRGB_D50));
+  v_color_twist_mode->addItem(colorTwistModeToString(COLOR_TWIST_MODE_WIDE_GAMUT_RGB_D50));
+  v_color_twist_mode->addItem(colorTwistModeToString(COLOR_TWIST_MODE_ADOBERGB_D65));
+  v_color_twist_mode->addItem(colorTwistModeToString(COLOR_TWIST_MODE_SRGB_D65));
+  
+  v_aoi_width = new VarInt("AOI width", 752, 0, 752);
+  v_aoi_height = new VarInt("AOI height", 480, 0, 480);
+  v_aoi_left = new VarInt("AOI left", 0, 0, 752);
+  v_aoi_top = new VarInt("AOI top", 0, 0, 480);
+  
+  dcam_parameters->addChild(v_aoi_width);
+  dcam_parameters->addChild(v_aoi_height);
+  dcam_parameters->addChild(v_aoi_left);
+  dcam_parameters->addChild(v_aoi_top);
+  dcam_parameters->addChild(v_expose_us);
+  dcam_parameters->addChild(v_expose_overlapped);
+  dcam_parameters->addChild(v_gain_db);
+  dcam_parameters->addChild(v_hdr_mode);
+  dcam_parameters->addChild(v_mirror_top_down);
+  dcam_parameters->addChild(v_mirror_left_right);
+  dcam_parameters->addChild(v_wb_red);
+  dcam_parameters->addChild(v_wb_green);
+  dcam_parameters->addChild(v_wb_blue);
+  dcam_parameters->addChild(v_sharpen);
+  dcam_parameters->addChild(v_gamma);
+  dcam_parameters->addChild(v_color_twist_mode);
+  
+  #ifndef VDATA_NO_QT
+    mvc_connect(dcam_parameters);
+    mutex.unlock();
+  #endif
+}
+
+#ifndef VDATA_NO_QT
+void CaptureBlueFox2::mvc_connect(VarList * group)
+{
+  vector<VarType *> v=group->getChildren();
+  for (unsigned int i=0;i<v.size();i++)
+  {
+    connect(v[i],SIGNAL(wasEdited(VarType *)),group,SLOT(mvcEditCompleted()));
+  }
+  connect(group,SIGNAL(wasEdited(VarType *)),this,SLOT(changed(VarType *)));
+}
+
+void CaptureBlueFox2::changed(VarType * group)
+{
+  if (group->getType()==VARTYPE_ID_LIST)
+  {
+    writeParameterValues( (VarList *)group );
+    readParameterValues( (VarList *)group );
+  }
+}
+#endif
+
+void CaptureBlueFox2::readAllParameterValues()
+{
+  readParameterValues(dcam_parameters);
+}
+
+void CaptureBlueFox2::writeAllParameterValues()
+{
+  writeParameterValues(dcam_parameters);
+}
+
+void CaptureBlueFox2::readParameterValues(VarList * item)
+{
+  if(item != dcam_parameters)
+    return;
+  
+  #ifndef VDATA_NO_QT
+    mutex.lock();
+  #endif
+    
+    // TODO: could do a read-out, but why?
+//   v_expose_us->setInt(pSettings->expose_us.read());
+    
+  #ifndef VDATA_NO_QT
+    mutex.unlock();
+  #endif
+}
+
+void CaptureBlueFox2::writeParameterValues(VarList * item)
+{
+  if(item != dcam_parameters)
+    return;
+
+  #ifndef VDATA_NO_QT
+    mutex.lock();
+  #endif
+  
+  pSettings->expose_us.write(v_expose_us->getInt());
+  
+  if(v_expose_overlapped->getBool())
+    pSettings->exposeMode.write(cemOverlapped);
+  else
+    pSettings->exposeMode.write(cemStandard);
+  
+  pSettings->gain_dB.write(v_gain_db->getDouble());
+  
+  pSettings->aoiStartX.write(v_aoi_left->getInt());
+  pSettings->aoiStartY.write(v_aoi_top->getInt());
+  pSettings->aoiWidth.write(v_aoi_width->getInt());
+  pSettings->aoiHeight.write(v_aoi_height->getInt());
+  
+  HDRMode hdrMode = stringToHdrMode(v_hdr_mode->getString().c_str());
+  
+  if(hdrMode == HDR_MODE_OFF)
+  {
+    pSettings->getHDRControl().HDREnable.write(bFalse);
+  }
+  else
+  {
+    pSettings->getHDRControl().HDREnable.write(bTrue);
+    
+    TCameraHDRMode hdr;
+    
+    switch(hdrMode)
+    {
+      case HDR_MODE_FIXED0: hdr = cHDRmFixed0; break;
+      case HDR_MODE_FIXED1: hdr = cHDRmFixed1; break;
+      case HDR_MODE_FIXED2: hdr = cHDRmFixed2; break;
+      case HDR_MODE_FIXED3: hdr = cHDRmFixed3; break;
+      case HDR_MODE_FIXED4: hdr = cHDRmFixed4; break;
+      default: hdr = cHDRmFixed5; break;
+    }
+    
+    pSettings->getHDRControl().HDRMode.write(hdr);
+  }
+  
+  int mm = mmOff;
+  if(v_mirror_top_down->getBool())
+    mm |= mmTopDown;
+  if(v_mirror_left_right->getBool())
+    mm |= mmLeftRight;
+  
+  pImageProc->mirrorOperationMode.write(momGlobal);
+  pImageProc->mirrorModeGlobal.write((TMirrorMode)mm);
+  
+  pImageProc->whiteBalance.write(wbpUser1);
+  WhiteBalanceSettings& wb = pImageProc->getWBUserSetting(0);
+  wb.WBAoiMode.write(amFull);
+  wb.totalGain.write(1.0);
+  wb.redGain.write(v_wb_red->getDouble());
+  wb.greenGain.write(v_wb_green->getDouble());
+  wb.blueGain.write(v_wb_blue->getDouble());
+  
+  if(v_sharpen->getBool())
+    pImageProc->filter.write(ipfSharpen);
+  else
+    pImageProc->filter.write(ipfOff);
+  
+  pImageProc->LUTEnable.write(bTrue);
+  pImageProc->LUTMode.write(LUTmGamma);
+  pImageProc->LUTImplementation.write(LUTiSoftware);
+  pImageProc->LUTMappingSoftware.write(LUTm10To10);
+  pImageProc->getLUTParameter(0).gamma.write(v_gamma->getDouble());
+  pImageProc->getLUTParameter(1).gamma.write(v_gamma->getDouble());
+  pImageProc->getLUTParameter(2).gamma.write(v_gamma->getDouble());
+  pImageProc->getLUTParameter(3).gamma.write(v_gamma->getDouble());
+  
+  ColorTwistMode ctMode = stringToColorTwistMode(v_color_twist_mode->getString().c_str());
+  
+  if(ctMode == COLOR_TWIST_MODE_OFF)
+  {
+    pImageProc->colorTwistInputCorrectionMatrixEnable.write(bFalse);
+    pImageProc->colorTwistEnable.write(bFalse);
+    pImageProc->colorTwistOutputCorrectionMatrixEnable.write(bFalse);
+  }
+  else
+  {
+    pImageProc->colorTwistInputCorrectionMatrixEnable.write(bTrue);
+    pImageProc->colorTwistInputCorrectionMatrixMode.write(cticmmDeviceSpecific);
+    pImageProc->colorTwistEnable.write(bTrue);
+    pImageProc->colorTwistOutputCorrectionMatrixEnable.write(bTrue);
+    
+    int ct;
+    switch(ctMode)
+    {
+      case COLOR_TWIST_MODE_ADOBERGB_D50: ct = ctocmmXYZToAdobeRGB_D50; break;
+      case COLOR_TWIST_MODE_SRGB_D50: ct = ctocmmXYZTosRGB_D50; break;
+      case COLOR_TWIST_MODE_WIDE_GAMUT_RGB_D50: ct = ctocmmXYZToWideGamutRGB_D50; break;
+      case COLOR_TWIST_MODE_ADOBERGB_D65: ct = ctocmmXYZToAdobeRGB_D65; break;
+      default: ct = ctocmmXYZTosRGB_D65; break;
+    }
+    
+    pImageProc->colorTwistOutputCorrectionMatrixMode.write((TColorTwistOutputCorrectionMatrixMode)ct);
+  }
+
+  #ifndef VDATA_NO_QT
+    mutex.unlock();
+  #endif
+}
+
+CaptureBlueFox2::~CaptureBlueFox2()
+{
+  //FIXME: delete all of dcam_parameters children
+}
+
+bool CaptureBlueFox2::resetBus()
+{
+  #ifndef VDATA_NO_QT
+    mutex.lock();
+  #endif
+
+  #ifndef VDATA_NO_QT
+    mutex.unlock();
+  #endif
+    
+  return true;
+}
+
+bool CaptureBlueFox2::stopCapture()
+{
+  if (isCapturing())
+  {
+    readAllParameterValues();
+    
+    pDevice->close();
+    
+    is_capturing = false;
+  }
+  
+  vector<VarType *> tmp = capture_settings->getChildren();
+  for (unsigned int i=0; i < tmp.size();i++)
+  {
+    tmp[i]->removeFlags( VARTYPE_FLAG_READONLY );
+  }
+  
+  dcam_parameters->addFlags( VARTYPE_FLAG_HIDE_CHILDREN );
+  
+  return true;
+}
+
+bool CaptureBlueFox2::startCapture()
+{
+  #ifndef VDATA_NO_QT
+    mutex.lock();
+  #endif
+    
+  //grab current parameters:
+  cam_id = v_cam_bus->getInt();
+  
+  const unsigned int devCnt = devMgr.deviceCount();
+  fprintf(stderr, "BlueFox2: Number of cams: %u\n", devCnt);
+  
+  if(cam_id >= devCnt)
+  {
+    fprintf(stderr, "BlueFox2: Invalid cam_id: %u\n", cam_id);
+
+    #ifndef VDATA_NO_QT
+      mutex.unlock();
+    #endif
+    return false;
+  }
+  
+  pDevice = devMgr[cam_id];
+  
+  try
+  {
+    pDevice->open();
+  }
+  catch(mvIMPACT::acquire::ImpactAcquireException& e)
+  {
+    // this e.g. might happen if the same device is already opened in another process...
+    fprintf(stderr, "BlueFox2: An error occurred while opening the device(error code: %d, '%s')\n", e.getErrorCode(), e.getErrorString().c_str());
+    #ifndef VDATA_NO_QT
+      mutex.unlock();
+    #endif
+    return false;
+  }
+  
+  fprintf(stderr, "BlueFox2: Opened: %s with serial ID %s\n", pDevice->family.read().c_str(), pDevice->serial.read().c_str());
+  
+  pFI = new FunctionInterface(pDevice);
+  
+  ImageDestination id( pDevice );
+  id.restoreDefault();
+  unsigned int pixelFormats = id.pixelFormat.dictSize();
+    // display all available pixel formats and there numerical representation.
+  for( unsigned int i = 0; i < pixelFormats; i++ )
+  {
+      fprintf(stderr, "[%d]: %s\n", id.pixelFormat.getTranslationDictValue( i ), id.pixelFormat.getTranslationDictString( i ).c_str());
+  }
+  
+  ColorFormat out_color = Colors::stringToColorFormat(v_colorout->getSelection().c_str());
+  if(out_color == COLOR_RGB8)
+  {
+    id.pixelFormat.write(idpfBGR888Packed);
+  }
+  else
+  {
+    id.pixelFormat.write(idpfYUV422Packed);
+  }
+  
+  pSettings = new CameraSettingsBlueFOX(pDevice);
+  pSettings->restoreDefault();
+  pSettings->pixelClock_KHz.write(cpc40000KHz);
+  
+  pImageProc = new ImageProcessing(pDevice);
+  pImageProc->restoreDefault();
+  
+  is_capturing = true;
+  
+  vector<VarType *> tmp = capture_settings->getChildren();
+  for (unsigned int i=0; i < tmp.size();i++) {
+    tmp[i]->addFlags( VARTYPE_FLAG_READONLY );
+  }
+    
+  dcam_parameters->removeFlags( VARTYPE_FLAG_HIDE_CHILDREN );
+
+  #ifndef VDATA_NO_QT
+    mutex.unlock();
+  #endif
+    
+  printf("BlueFox2 Info: Restoring Previously Saved Camera Parameters\n");
+  writeAllParameterValues();
+  readAllParameterValues();
+}
+
+bool CaptureBlueFox2::copyAndConvertFrame(const RawImage & src, RawImage & target)
+{
+  #ifndef VDATA_NO_QT
+    mutex.lock();
+  #endif
+    
+  ColorFormat src_fmt = src.getColorFormat();
+  
+  if(target.getData() == 0)
+  {
+    //allocate target, if it does not exist yet
+    target.allocate(src_fmt, src.getWidth(), src.getHeight());
+  } 
+  else
+  {
+    target.ensure_allocation(src_fmt, src.getWidth(), src.getHeight());
+  }
+  target.setTime(src.getTime());
+  
+  if(src.getColorFormat() == COLOR_RGB8)
+  {
+    memcpy(target.getData(),src.getData(),src.getNumBytes());
+  }
+  else
+  {
+    for(unsigned int i = 0; i < src.getNumBytes(); i += 2)
+    {
+      target.getData()[i+1] = src.getData()[i];
+      target.getData()[i] = src.getData()[i+1];
+    }
+  }
+  
+  #ifndef VDATA_NO_QT
+    mutex.unlock();
+  #endif
+
+  return true;
+}
+
+RawImage CaptureBlueFox2::getFrame()
+{
+  #ifndef VDATA_NO_QT
+    mutex.lock();
+  #endif
+    
+  RawImage result;
+  result.setColorFormat(capture_format);
+  result.setWidth(0);
+  result.setHeight(0);
+  result.setTime(0.0);
+  result.setData(0);
+  
+  // make sure the request queue is always filled
+  while((static_cast<TDMR_ERROR>( pFI->imageRequestSingle() ) ) == DMR_NO_ERROR ) {};
+  
+  int requestNr = pFI->imageRequestWaitFor(-1);
+
+  // check if the image has been captured without any problems.
+  if(!pFI->isRequestNrValid(requestNr))
+  {
+      // If the error code is -2119(DEV_WAIT_FOR_REQUEST_FAILED), the documentation will provide
+      // additional information under TDMR_ERROR in the interface reference
+      fprintf(stderr, "imageRequestWaitFor failed (%d, %s)\n", requestNr, ImpactAcquireException::getErrorCodeAsString( requestNr ).c_str());
+      #ifndef VDATA_NO_QT
+	mutex.unlock();
+      #endif
+      return result;
+  }
+
+  const Request* pRequest = pFI->getRequest(requestNr);
+
+  if(pRequest->isOK())
+  {
+    timeval tv;
+    gettimeofday(&tv,NULL);
+    result.setTime((double)tv.tv_sec + tv.tv_usec*(1.0E-6));
+    result.setWidth(pRequest->imageWidth.read());
+    result.setHeight(pRequest->imageHeight.read());
+    ColorFormat out_color = Colors::stringToColorFormat(v_colorout->getSelection().c_str());
+    result.setColorFormat(out_color);
+    result.setData((unsigned char*)pRequest->imageData.read());
+//     fprintf(stderr, "Timestamp_us: %ld\n", pRequest->infoTimeStamp_us.read());
+//     fprintf(stderr, "BPP: %u\n", pRequest->imageBytesPerPixel.read());
+//     fprintf(stderr, "PixelFormat: %s\n", pRequest->imagePixelFormat.readS().c_str());
+  }
+  else
+  {
+    fprintf(stderr, "BlueFox2: request not OK\n");
+  }
+  
+  lastRequestNr = requestNr;
+  
+  #ifndef VDATA_NO_QT
+    mutex.unlock();
+  #endif
+  return result;
+}
+
+void CaptureBlueFox2::releaseFrame() 
+{
+  #ifndef VDATA_NO_QT
+    mutex.lock();
+  #endif
+    
+  if(pFI->isRequestNrValid(lastRequestNr))
+    pFI->imageRequestUnlock(lastRequestNr);
+  
+  #ifndef VDATA_NO_QT
+    mutex.unlock();
+  #endif
+}
+
+string CaptureBlueFox2::getCaptureMethodName() const 
+{
+  return "BlueFox2";
+}

--- a/src/shared/capture/capture_bluefox2.h
+++ b/src/shared/capture/capture_bluefox2.h
@@ -114,13 +114,13 @@ class CaptureBlueFox2 : public CaptureInterface
   {
     switch(mode)
     {
-      case HDR_MODE_OFF: return "Off";
       case HDR_MODE_FIXED0: return "Fixed0";
       case HDR_MODE_FIXED1: return "Fixed1";
       case HDR_MODE_FIXED2: return "Fixed2";
       case HDR_MODE_FIXED3: return "Fixed3";
       case HDR_MODE_FIXED4: return "Fixed4";
       case HDR_MODE_FIXED5: return "Fixed5";
+      default: return "Off";
     }
   }
   
@@ -157,12 +157,12 @@ class CaptureBlueFox2 : public CaptureInterface
   {
     switch(mode)
     {
-      case COLOR_TWIST_MODE_OFF: return "Off";
       case COLOR_TWIST_MODE_ADOBERGB_D50: return "AdobeRGB_D50";
       case COLOR_TWIST_MODE_SRGB_D50: return "sRGB_D50";
       case COLOR_TWIST_MODE_WIDE_GAMUT_RGB_D50: return "WideGamutRGB_D50";
       case COLOR_TWIST_MODE_ADOBERGB_D65: return "AdobeRGB_D65";
       case COLOR_TWIST_MODE_SRGB_D65: return "sRGB_D65";
+      default: return "Off";
     }
   }
   

--- a/src/shared/capture/capture_bluefox2.h
+++ b/src/shared/capture/capture_bluefox2.h
@@ -1,0 +1,243 @@
+//========================================================================
+//  This software is free: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License Version 3,
+//  as published by the Free Software Foundation.
+//
+//  This software is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  Version 3 in the file COPYING that came with this distribution.
+//  If not, see <http://www.gnu.org/licenses/>.
+//========================================================================
+/*!
+  \file    capture_bluefox2.h
+  \brief   C++ Interface: CaptureBlueFox2
+  \author  Andre Ryll, (C) 2016
+*/
+//========================================================================
+
+#ifndef CAPTURE_BLUEFOX2_H
+#define CAPTURE_BLUEFOX2_H
+#include "captureinterface.h"
+#include <sys/time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include "VarTypes.h"
+#include <mvIMPACT_CPP/mvIMPACT_acquire.h>
+
+//#include "conversions.h"
+#ifndef VDATA_NO_QT
+  #include <QMutex>
+#else
+  #include <pthread.h>
+#endif
+
+using namespace mvIMPACT::acquire;
+
+/*!
+  \class CaptureBlueFox2
+  \brief A capture class for Matrix-Vision BlueFox2 cameras
+  \author  Andre Ryll, (C) 2016
+
+  This class provides the ability to use and configure Matrix-Vision
+  BlueFox2 cameras using the mvIMPACT driver.
+
+  Overall, it not only provides capture-abilities, but also full
+  on-the-fly configuration abilities through the VarTypes system.
+ 
+  If you find your camera not working correctly, or discover a bug,
+  please inform the author, as we are aiming for complete camera
+  coverage.
+*/
+#ifndef VDATA_NO_QT
+  #include <QMutex>
+  //if using QT, inherit QObject as a base
+class CaptureBlueFox2 : public QObject, public CaptureInterface
+#else
+class CaptureBlueFox2 : public CaptureInterface
+#endif
+{
+#ifndef VDATA_NO_QT
+  Q_OBJECT
+  
+  public slots:
+  void changed(VarType * group);
+  
+  protected:
+  QMutex mutex;
+  
+  public:
+#endif
+
+  enum HDRMode
+  {
+    HDR_MODE_OFF,
+    HDR_MODE_FIXED0,
+    HDR_MODE_FIXED1,
+    HDR_MODE_FIXED2,
+    HDR_MODE_FIXED3,
+    HDR_MODE_FIXED4,
+    HDR_MODE_FIXED5,
+  };
+  
+  static HDRMode stringToHdrMode(const char* s)
+  {
+    if (strcmp(s,"Off")==0) {
+      return HDR_MODE_OFF;
+    } else if (strcmp(s,"Fixed0")==0) {
+      return HDR_MODE_FIXED0;
+    } else if (strcmp(s,"Fixed1")==0) {
+      return HDR_MODE_FIXED1;
+    } else if (strcmp(s,"Fixed2")==0) {
+      return HDR_MODE_FIXED2;
+    } else if (strcmp(s,"Fixed3")==0) {
+      return HDR_MODE_FIXED3;
+    } else if (strcmp(s,"Fixed4")==0) {
+      return HDR_MODE_FIXED4;
+    } else if (strcmp(s,"Fixed5")==0) {
+      return HDR_MODE_FIXED5;
+    } else {
+      return HDR_MODE_OFF;
+    }
+  }
+  
+  static string hdrModeToString(HDRMode mode)
+  {
+    switch(mode)
+    {
+      case HDR_MODE_OFF: return "Off";
+      case HDR_MODE_FIXED0: return "Fixed0";
+      case HDR_MODE_FIXED1: return "Fixed1";
+      case HDR_MODE_FIXED2: return "Fixed2";
+      case HDR_MODE_FIXED3: return "Fixed3";
+      case HDR_MODE_FIXED4: return "Fixed4";
+      case HDR_MODE_FIXED5: return "Fixed5";
+    }
+  }
+  
+  enum ColorTwistMode
+  {
+    COLOR_TWIST_MODE_OFF,
+    COLOR_TWIST_MODE_ADOBERGB_D50,
+    COLOR_TWIST_MODE_SRGB_D50,
+    COLOR_TWIST_MODE_WIDE_GAMUT_RGB_D50,
+    COLOR_TWIST_MODE_ADOBERGB_D65,
+    COLOR_TWIST_MODE_SRGB_D65,
+  };
+  
+  static ColorTwistMode stringToColorTwistMode(const char* s)
+  {
+      if (strcmp(s,"Off")==0) {
+      return COLOR_TWIST_MODE_OFF;
+    } else if (strcmp(s,"AdobeRGB_D50")==0) {
+      return COLOR_TWIST_MODE_ADOBERGB_D50;
+    } else if (strcmp(s,"sRGB_D50")==0) {
+      return COLOR_TWIST_MODE_SRGB_D50;
+    } else if (strcmp(s,"WideGamutRGB_D50")==0) {
+      return COLOR_TWIST_MODE_WIDE_GAMUT_RGB_D50;
+    } else if (strcmp(s,"AdobeRGB_D65")==0) {
+      return COLOR_TWIST_MODE_ADOBERGB_D65;
+    } else if (strcmp(s,"sRGB_D65")==0) {
+      return COLOR_TWIST_MODE_SRGB_D65;
+    } else {
+      return COLOR_TWIST_MODE_OFF;
+    }
+  }
+  
+  static string colorTwistModeToString(ColorTwistMode mode)
+  {
+    switch(mode)
+    {
+      case COLOR_TWIST_MODE_OFF: return "Off";
+      case COLOR_TWIST_MODE_ADOBERGB_D50: return "AdobeRGB_D50";
+      case COLOR_TWIST_MODE_SRGB_D50: return "sRGB_D50";
+      case COLOR_TWIST_MODE_WIDE_GAMUT_RGB_D50: return "WideGamutRGB_D50";
+      case COLOR_TWIST_MODE_ADOBERGB_D65: return "AdobeRGB_D65";
+      case COLOR_TWIST_MODE_SRGB_D65: return "sRGB_D65";
+    }
+  }
+
+
+protected:
+  bool is_capturing;
+
+  //DCAM parameters:
+  VarInt* v_expose_us;
+  VarBool* v_expose_overlapped;
+  VarDouble* v_gain_db;
+  VarStringEnum* v_hdr_mode;
+  VarBool* v_mirror_top_down;
+  VarBool* v_mirror_left_right;
+  VarDouble* v_wb_red;
+  VarDouble* v_wb_green;
+  VarDouble* v_wb_blue;
+  VarBool* v_sharpen;
+  VarDouble* v_gamma;
+  VarStringEnum* v_color_twist_mode;
+  VarInt    * v_aoi_width;
+  VarInt    * v_aoi_height;
+  VarInt    * v_aoi_left;
+  VarInt    * v_aoi_top;
+  
+  //capture variables:
+  VarInt    * v_cam_bus;
+  VarStringEnum * v_colorout;
+  
+  VarList * dcam_parameters;
+  VarList * capture_settings;
+  
+  // BlueFox2 specific data
+  DeviceManager devMgr;
+  Device* pDevice;
+  FunctionInterface* pFI;
+  CameraSettingsBlueFOX* pSettings;
+  ImageProcessing* pImageProc;
+  int lastRequestNr;
+
+  unsigned int cam_id;
+  ColorFormat capture_format;
+
+public:
+  #ifndef VDATA_NO_QT
+    CaptureBlueFox2(VarList * _settings=0,int default_camera_id=0,QObject * parent=0);
+    void mvc_connect(VarList * group);
+  #else
+    CaptureBlueFox2(VarList * _settings=0,int default_camera_id=0);
+  #endif
+  ~CaptureBlueFox2();
+
+  /// Initialize the interface and start capture
+  virtual bool startCapture();
+
+  /// Stop Capture
+  virtual bool stopCapture();
+
+  virtual bool isCapturing() { return is_capturing; };
+
+  /// this gives a raw-image with a pointer directly to the video-buffer
+  /// Note that this pointer is only guaranteed to point to a valid
+  /// memory location until releaseFrame() is called.
+  virtual RawImage getFrame();
+
+  virtual void releaseFrame();
+
+  virtual bool resetBus();
+
+  void readParameterValues(VarList * item);
+
+  void writeParameterValues(VarList * item);
+
+  virtual void readAllParameterValues();
+
+  void writeAllParameterValues();
+
+  virtual bool copyAndConvertFrame(const RawImage & src, RawImage & target);
+
+  virtual string getCaptureMethodName() const;
+};
+
+#endif

--- a/src/shared/capture/capture_bluefox2.h
+++ b/src/shared/capture/capture_bluefox2.h
@@ -36,6 +36,11 @@
   #include <pthread.h>
 #endif
 
+namespace mvIMPACT {
+namespace acquire {
+enum TCameraPixelClock;}
+}
+
 using namespace mvIMPACT::acquire;
 
 /*!
@@ -160,6 +165,45 @@ class CaptureBlueFox2 : public CaptureInterface
       case COLOR_TWIST_MODE_SRGB_D65: return "sRGB_D65";
     }
   }
+  
+  static TCameraPixelClock stringToPixelClock(const char* s)
+  {
+    if (strcmp(s,"8MHz")==0) {
+      return cpc8000KHz;
+    } else if (strcmp(s,"10MHz")==0) {
+      return cpc10000KHz;
+    } else if (strcmp(s,"12MHz")==0) {
+      return cpc12000KHz;
+    } else if (strcmp(s,"20MHz")==0) {
+      return cpc20000KHz;
+    } else if (strcmp(s,"24MHz")==0) {
+      return cpc24000KHz;
+    } else if (strcmp(s,"27MHz")==0) {
+      return cpc27000KHz;
+    } else if (strcmp(s,"32MHz")==0) {
+      return cpc32000KHz;
+    } else if (strcmp(s,"40MHz")==0) {
+      return cpc40000KHz;
+    } else {
+      return cpc6000KHz;
+    }
+  }
+
+  static string pixelClockToString(TCameraPixelClock pxc)
+  {
+    switch(pxc)
+    {
+      case cpc8000KHz: return "8MHz";
+      case cpc10000KHz: return "10MHz";
+      case cpc12000KHz: return "12MHz";
+      case cpc20000KHz: return "20MHz";
+      case cpc24000KHz: return "24MHz";
+      case cpc27000KHz: return "27MHz";
+      case cpc32000KHz: return "32MHz";
+      case cpc40000KHz: return "40MHz";
+      default: return "6MHz";
+    }
+  }
 
 
 protected:
@@ -182,6 +226,7 @@ protected:
   VarInt    * v_aoi_height;
   VarInt    * v_aoi_left;
   VarInt    * v_aoi_top;
+  VarStringEnum* v_pixel_clock;
   
   //capture variables:
   VarInt    * v_cam_bus;


### PR DESCRIPTION
I have recently added support for Matrix-Vision's BlueFox2 cameras. It is fully tested with up to two mvBlueFOX-MLC200wC cameras (attached to an Intel NUC i5). Those cameras are cheaper than FireWire cameras (~250€ with lens) and easier to use (USB2.0). Especially for new teams this could be of interest. Cameras go up to 93fps. A Core i7 is recommended if you want to use 4 cameras.

Support for BlueFox2 cameras is automatically compiled into SSL-Vision if the mvIMPACT_acquire library is found on your computer. Otherwise, support for this camera is silently disabled.
