### PR TITLE
InstallPackage<OS>.sh scripts

### DIFF
--- a/InstallPackagesArch.sh
+++ b/InstallPackagesArch.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# These are the packages required for install on Arch Linux systems.
+sudo pacman -Sy gcc qt4 eigen protobuf libdc1394 cmake v4l-utils jsoncpp

--- a/InstallPackagesUbuntu.sh
+++ b/InstallPackagesUbuntu.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# These are the packages required for install on Ubuntu systems.
+sudo apt-get install g++ libqt4-dev libeigen3-dev protobuf-compiler libprotobuf-dev libdc1394-22 libdc1394-22-dev cmake libv4l-0

--- a/README.md
+++ b/README.md
@@ -40,14 +40,9 @@
  * libpng
  * video for linux 2 (v4l)
 
-To get all of these packages in (k)ubuntu, run:
-```
-    sudo apt-get install g++ libqt4-dev libeigen3-dev protobuf-compiler libprotobuf-dev libdc1394-22 libdc1394-22-dev cmake libv4l-0
-```
-Or in archlinux, run:
-```
-$ pacman -Sy gcc qt4 eigen protobuf libdc1394 cmake v4l-utils jsoncpp
-```
+To get all of these packages in (k)ubuntu, run the `InstallPackagesUbuntu.sh` script.
+
+Or, in archlinux, run the `InstallPackagesArch.sh` script.
 
 ## Hardware Requirements
  * The system supports 1394B / Firewire 800, but it's also backward compatible with 1394A.


### PR DESCRIPTION
I have converted the lines in the README listing what packages to install into scripts that can be easily run.

This makes the codebase easier to get up and running without the need to copy and paste specific lines of the README into the console.