### PR TITLE
Fix warnings when compiling ssl-vision with protobuf 3+

### DIFF
--- a/src/shared/proto/messages_robocup_ssl_detection.proto
+++ b/src/shared/proto/messages_robocup_ssl_detection.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 message SSL_DetectionBall {
   required float  confidence = 1;
   optional uint32 area       = 2;

--- a/src/shared/proto/messages_robocup_ssl_geometry.proto
+++ b/src/shared/proto/messages_robocup_ssl_geometry.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 // A 2D float vector.
 message Vector2f {
   required float x = 1;

--- a/src/shared/proto/messages_robocup_ssl_geometry_legacy.proto
+++ b/src/shared/proto/messages_robocup_ssl_geometry_legacy.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "messages_robocup_ssl_geometry.proto";
 package RoboCup2014Legacy.Geometry;
 

--- a/src/shared/proto/messages_robocup_ssl_refbox_log.proto
+++ b/src/shared/proto/messages_robocup_ssl_refbox_log.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "messages_robocup_ssl_detection.proto";
 
 message Log_Frame

--- a/src/shared/proto/messages_robocup_ssl_wrapper.proto
+++ b/src/shared/proto/messages_robocup_ssl_wrapper.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "messages_robocup_ssl_detection.proto";
 import "messages_robocup_ssl_geometry.proto";
 

--- a/src/shared/proto/messages_robocup_ssl_wrapper_legacy.proto
+++ b/src/shared/proto/messages_robocup_ssl_wrapper_legacy.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "messages_robocup_ssl_detection.proto";
 import "messages_robocup_ssl_geometry_legacy.proto";
 


### PR DESCRIPTION
Previously, compiling ssl-vision with a protobuf version >=3 resulted in these warnings:

```
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: messages_robocup_ssl_detection.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[  0%] Generating messages_robocup_ssl_geometry.pb.cc, messages_robocup_ssl_geometry.pb.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: messages_robocup_ssl_geometry.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[  1%] Generating messages_robocup_ssl_wrapper.pb.cc, messages_robocup_ssl_wrapper.pb.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: messages_robocup_ssl_wrapper.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: messages_robocup_ssl_detection.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: messages_robocup_ssl_geometry.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[  1%] Generating messages_robocup_ssl_refbox_log.pb.cc, messages_robocup_ssl_refbox_log.pb.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: messages_robocup_ssl_refbox_log.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: messages_robocup_ssl_detection.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[  2%] Generating messages_robocup_ssl_geometry_legacy.pb.cc, messages_robocup_ssl_geometry_legacy.pb.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: messages_robocup_ssl_geometry_legacy.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: messages_robocup_ssl_geometry.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[  2%] Generating messages_robocup_ssl_wrapper_legacy.pb.cc, messages_robocup_ssl_wrapper_legacy.pb.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: messages_robocup_ssl_wrapper_legacy.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: messages_robocup_ssl_detection.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: messages_robocup_ssl_geometry_legacy.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: messages_robocup_ssl_geometry.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
make[3]: Leaving directory '/home/jay/Code/tmp/ssl-vision/build'
```

This PR adds the explicit syntax 2 and as such removes the warning from the build logs.

This should be functionally identical, only squelching the warnings.