### PR TITLE
Add a warning when running vision from a non-standard directory

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -57,7 +57,7 @@ void printPathWarning() {
   std::string binaryPath = std::string(binaryPathRaw, count);
 
   // Get the offset to check
-  unsigned int offset = binaryPath.size() - (binaryPath.size() - currentWorkingDir.size());
+  unsigned int offset = currentWorkingDir.size();
   if (offset == 0 || offset >= binaryPath.size()){
     return;
   }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -44,7 +44,12 @@ void HandleStop(int i) {
 // Print a path warning if the running directory is NOT one level above the binary directory
 void printPathWarning() {
   char cwd[PATH_MAX];
-  getcwd(cwd, PATH_MAX);
+  char* result = getcwd(cwd, PATH_MAX);
+  if (!result) {
+    // We failed getting the cwd, abort
+    return;
+  }
+
   std::string currentWorkingDir = cwd;
 
   char binaryPathRaw[PATH_MAX];

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -68,9 +68,16 @@ void printPathWarning() {
   }
 
   if (binaryPath.substr(offset, string::npos) != "/bin/vision") {
-    std::cout << std::endl << "[WARNING] You are running vision from the wrong directory." << std::endl;
-    std::cout << "Please run ssl-vision from the root of the git repo unless you know what you are doing." << std::endl;
-    std::cout << "(run with: ./bin/vision)" << std::endl << std::endl;
+    std::string warningMsg = "[WARNING] You are running vision from a non-standard directory.\n"
+      "Please run ssl-vision from the root of the git repo unless you know what you are doing.\n"
+      "(run with: ./bin/vision)\n";
+
+    std::cout << std::endl << warningMsg << std::endl;
+
+    // display a message box
+    QMessageBox msgBox;
+    msgBox.setText(QString::fromUtf8(warningMsg.c_str()));
+    msgBox.exec();
   }
 }
 


### PR DESCRIPTION
During RoboCup 2017, there were two independent instances where someone ran vision from the `./bin` folder, which lost all configuration, and caused a lot of confusion.

There's also the problem in #76, where the config system has a bunch of variables that expect the root of the repo to be the cwd.

To try to solve both of these problems, I've added a warning which will print when running from a directory other than the root of the repo. It's a little bit ugly, unfortunately, because I don't think ssl-vision uses boost (so I can't use `boost::filesystem`), but it's a start.

Let me know if you have any feedback :smile: 