### PR TITLE
Choose a random free port instead of the target port for local bind

### DIFF
--- a/src/shared/net/robocup_ssl_server.cpp
+++ b/src/shared/net/robocup_ssl_server.cpp
@@ -42,8 +42,8 @@ void RoboCupSSLServer::close() {
 
 bool RoboCupSSLServer::open() {
   close();
-  if(!mc.open(_port,true,true)) {
-    fprintf(stderr,"Unable to open UDP network port: %d\n",_port);
+  if(!mc.open(0,true,true)) {
+    fprintf(stderr,"Unable to open UDP network\n");
     fflush(stderr);
     return(false);
   }


### PR DESCRIPTION
If some other applications also binds to the same local port and forgets to also set SO_REUSEPORT, the bind will fail.
There is no reason for binding to a fixed local port in this case.