### PR TITLE
plugin_neuralcolorcalib: don't accept every mouseReleaseEvent

### DIFF
--- a/src/app/plugins/plugin_neuralcolorcalib.cpp
+++ b/src/app/plugins/plugin_neuralcolorcalib.cpp
@@ -259,9 +259,7 @@ void PluginNeuralColorCalib::mousePressEvent ( QMouseEvent * event, pixelloc loc
 }
 
 void PluginNeuralColorCalib::mouseReleaseEvent ( QMouseEvent * event, pixelloc loc ) {
-    event->accept();
-    //continuing_undo = false;
-    //mouseEvent(event,loc);
+    mouseEvent(event,loc);
 }
 
 void PluginNeuralColorCalib::mouseMoveEvent ( QMouseEvent * event, pixelloc loc ) {


### PR DESCRIPTION
Previously, ssl-vision crashed when dragging a control point used for camera geometry calibrtion and afterwards dragging without hitting a calibration point.

This happend due to plugin_cameracalib relieing on the fact that there is always a mouseReleaseEvent for every mousePressEvent. This did not hold true as
plugin_neuralcolorcalib always accepted mouseReleaseEvents and is prior in the plugin queue. This results in dereferencing an nullptr in plugin_cameracalib.cpp in ln. 343
as soon as a drag event fires after an unsuccessful mousePressEvent (because of not hitting the control point).

Signed-off-by: Andreas Wendler <andreas.wendler@robotics-erlangen.de>
Signed-off-by: Tobias Heineken <tobias.heineken@robotics-erlangen.de>
Signed-off-by: Paul Bergmann <paul.bergmann@robotics-erlangen.de>