### PR TITLE
Split camera images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,12 +209,14 @@ set (SRCS
 	src/app/plugins/plugin_legacysslnetworkoutput.cpp
 	src/app/plugins/plugin_visualize.cpp
 	src/app/plugins/plugin_dvr.cpp
+	src/app/plugins/plugin_distribute.cpp
 	src/app/plugins/visionplugin.cpp
 
 	src/app/stacks/multistack_robocup_ssl.cpp
 	src/app/stacks/multivisionstack.cpp
 	src/app/stacks/stack_robocup_ssl.cpp
 	src/app/stacks/visionstack.cpp
+	src/app/stacks/DistributorStack.cpp
 
 	${OPTIONAL_SRCS}
 )

--- a/src/app/capture_thread.cpp
+++ b/src/app/capture_thread.cpp
@@ -287,12 +287,13 @@ void CaptureThread::run() {
                 stack->updateTimingStatistics();
                 stack_mutex.unlock();
               }
-              capture_mutex.lock();
-              if ((capture != nullptr) && (capture->isCapturing())) {
-                capture->releaseFrame();
-              }
-              capture_mutex.unlock();
           }
+
+          capture_mutex.lock();
+          if ((capture != nullptr) && (capture->isCapturing())) {
+            capture->releaseFrame();
+          }
+          capture_mutex.unlock();
         } else {
           stats->total=d->number=counter->getTotal();
           stats->fps_capture=counter->getFPS(changed);

--- a/src/app/capture_thread.cpp
+++ b/src/app/capture_thread.cpp
@@ -20,6 +20,7 @@
 //========================================================================
 
 #include "capture_thread.h"
+#include <capture_splitter.h>
 
 CaptureThread::CaptureThread(int cam_id)
 {
@@ -39,9 +40,11 @@ CaptureThread::CaptureThread(int cam_id)
   captureModule->addItem("Video 4 Linux");
   captureModule->addItem("Read from files");
   captureModule->addItem("Generator");
+  captureModule->addItem("Splitter");
   settings->addChild( (VarType*) (v4l = new VarList("Video 4 Linux")));
   settings->addChild( (VarType*) (fromfile = new VarList("Read from files")));
   settings->addChild( (VarType*) (generator = new VarList("Generator")));
+  settings->addChild( (VarType*) (splitter = new VarList("Splitter")));
   settings->addFlags( VARTYPE_FLAG_AUTO_EXPAND_TREE );
   c_stop->addFlags( VARTYPE_FLAG_READONLY );
   c_refresh->addFlags( VARTYPE_FLAG_READONLY );
@@ -56,6 +59,7 @@ CaptureThread::CaptureThread(int cam_id)
   captureFiles = new CaptureFromFile(fromfile, camId);
   captureGenerator = new CaptureGenerator(generator);
   captureV4L = new CaptureV4L(v4l,camId);
+  captureSplitter = new CaptureSplitter(splitter, cam_id);
 
 #ifdef DC1394
   captureModule->addItem("DC 1394");
@@ -114,6 +118,7 @@ CaptureThread::~CaptureThread()
   delete captureV4L;
   delete captureFiles;
   delete captureGenerator;
+  delete captureSplitter;
   delete counter;
 
 #ifdef PYLON5
@@ -151,6 +156,8 @@ void CaptureThread::selectCaptureMethod() {
   CaptureInterface * new_capture=nullptr;
   if(captureModule->getString() == "Read from files") {
     new_capture = captureFiles;
+  } else if(captureModule->getString() == "Splitter") {
+    new_capture = captureSplitter;
   } else if(captureModule->getString() == "Generator") {
     new_capture = captureGenerator;
 #ifdef MVIMPACT2

--- a/src/app/capture_thread.h
+++ b/src/app/capture_thread.h
@@ -25,6 +25,7 @@
 #include "capturefromfile.h"
 #include "capturev4l.h"
 #include "capture_generator.h"
+#include "capture_splitter.h"
 #include <QThread>
 #include "ringbuffer.h"
 #include "framedata.h"
@@ -70,6 +71,7 @@ protected:
   CaptureInterface * captureFiles;
   CaptureInterface * captureGenerator;
   CaptureInterface * captureBasler;
+  CaptureInterface * captureSplitter;
   AffinityManager * affinity;
   FrameBuffer * rb;
   bool _kill;
@@ -83,6 +85,7 @@ protected:
   VarList * generator;
   VarList * fromfile;
   VarList * basler;
+  VarList * splitter;
   VarList * control;
   VarTrigger * c_start;
   VarTrigger * c_stop;
@@ -107,6 +110,7 @@ public:
   void kill();
   VarList * getSettings();
   void setAffinityManager(AffinityManager * _affinity);
+  CaptureInterface* getCaptureSplitter() {return captureSplitter;};
   CaptureThread(int cam_id);
   ~CaptureThread();
 

--- a/src/app/gui/mainwindow.cpp
+++ b/src/app/gui/mainwindow.cpp
@@ -21,7 +21,7 @@
 
 #include "mainwindow.h"
 
-MainWindow::MainWindow(bool start_capture, bool enforce_affinity)
+MainWindow::MainWindow(bool start_capture, bool enforce_affinity, int num_cameras)
 {
 
   affinity=0;
@@ -50,7 +50,7 @@ MainWindow::MainWindow(bool start_capture, bool enforce_affinity)
   //opt->parse();
 
   //load RoboCup SSL stack by default:
-  multi_stack= new MultiStackRoboCupSSL(opts);
+  multi_stack= new MultiStackRoboCupSSL(opts, num_cameras);
 
   VarExternal * stackvar;
   root->addChild(stackvar= new VarExternal((multi_stack->getSettingsFileName() + ".xml").c_str(),multi_stack->getName()));
@@ -64,7 +64,11 @@ MainWindow::MainWindow(bool start_capture, bool enforce_affinity)
     GLWidget * gl=new GLWidget(0,false);
     gl->setRingBuffer(multi_stack->threads[i]->getFrameBuffer());
     gl->setVisionStack(s);
-    QString label = "Camera " + QString::number(i);
+    QString label = "Thread " + QString::number(i);
+    if(i == multi_stack->threads.size() - 1)
+    {
+      label = "Distributor Thread";
+    }
 
     VarList * threadvar = new VarList(label.toStdString());
 

--- a/src/app/gui/mainwindow.cpp
+++ b/src/app/gui/mainwindow.cpp
@@ -50,7 +50,7 @@ MainWindow::MainWindow(bool start_capture, bool enforce_affinity)
   //opt->parse();
 
   //load RoboCup SSL stack by default:
-  multi_stack=new MultiStackRoboCupSSL(opts, 4);
+  multi_stack= new MultiStackRoboCupSSL(opts);
 
   VarExternal * stackvar;
   root->addChild(stackvar= new VarExternal((multi_stack->getSettingsFileName() + ".xml").c_str(),multi_stack->getName()));

--- a/src/app/gui/mainwindow.cpp
+++ b/src/app/gui/mainwindow.cpp
@@ -196,7 +196,7 @@ void MainWindow::timerEvent( QTimerEvent * e) {
     if (fb!=0) {
       fb->lockRead();
       int cur=fb->curRead();
-      if (fb->nextRead(false) != cur) frame_changed=true;
+      if (fb->nextRead(true) != cur) frame_changed=true;
       fb->unlockRead();
     }
     w->displayLoopEvent(frame_changed,opts);

--- a/src/app/gui/mainwindow.h
+++ b/src/app/gui/mainwindow.h
@@ -68,7 +68,7 @@ public:
 
   MultiVisionStack * multi_stack;
 
-  MainWindow(bool start_capture, bool enforce_affinity);
+  MainWindow(bool start_capture, bool enforce_affinity, int num_cameras);
   virtual ~MainWindow();
   void init();
   void Quit() { emit close(); }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -88,12 +88,22 @@ int main(int argc, char *argv[])
   bool help=false;
   bool start=false;
   bool enforce_affinity=false;
+  QString camera_count;
   int ecode=0;
   opts.addSwitch("help",&help);
   opts.addShortOptSwitch( 'a',QString("Enforce Processor Affinity"),&enforce_affinity, false);
   opts.addShortOptSwitch( 's',QString("Start Capturing Immediately"),&start, false);
+  opts.addOptionalOption( 'c',QString("Camera Count"),&camera_count, QString("4"));
   if (!opts.parse()) {
     fprintf(stderr,"Invalid command line parameters!\n");
+    help=true;
+    ecode=1;
+  }
+
+  bool camera_count_ok = false;
+  int num_cameras = camera_count.toInt(&camera_count_ok);
+  if(!camera_count_ok) {
+    fprintf(stderr,"Invalid number of cameras!\n");
     help=true;
     ecode=1;
   }
@@ -102,13 +112,14 @@ int main(int argc, char *argv[])
     printf("SSL-Vision command line options:\n");
     printf(" -s        Start capture immediately\n");
     printf(" -a        Set Processor Affinity\n");
+    printf(" -c <n>    Set Number of Cameras\n");
     printf(" --help    Show this help\n");
     exit(ecode);
   }
 
   printPathWarning();
 
-  MainWindow mainWin(start, enforce_affinity);
+  MainWindow mainWin(start, enforce_affinity, num_cameras);
   mainWinPtr = &mainWin;
   mainWin.show();
   mainWin.init();

--- a/src/app/plugins/plugin_distribute.cpp
+++ b/src/app/plugins/plugin_distribute.cpp
@@ -73,8 +73,11 @@ ProcessResult PluginDistribute::process(FrameData *data,
   if (data == 0)
     return ProcessingFailed;
 
-  for(int i=0;i<captureSplitters.size();i++) {
-    captureSplitters[i]->onNewFrame(&data->video);
+  for (auto &captureSplitter : captureSplitters) {
+    captureSplitter->onNewFrame(&data->video);
+  }
+  for (auto &captureSplitter : captureSplitters) {
+    captureSplitter->waitUntilFrameProcessed();
   }
 
   VisualizationFrame *vis_frame =

--- a/src/app/plugins/plugin_distribute.cpp
+++ b/src/app/plugins/plugin_distribute.cpp
@@ -1,0 +1,111 @@
+//========================================================================
+//  This software is free: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License Version 3,
+//  as published by the Free Software Foundation.
+//
+//  This software is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  Version 3 in the file COPYING that came with this distribution.
+//  If not, see <http://www.gnu.org/licenses/>.
+//========================================================================
+
+#include "plugin_distribute.h"
+
+PluginDistribute::PluginDistribute(FrameBuffer *_buffer, vector<CaptureSplitter *> captureSplitters)
+    : VisionPlugin(_buffer),
+      captureSplitters(std::move(captureSplitters)) {
+  _v_enabled = new VarBool("enable", true);
+  _v_image = new VarBool("image", true);
+  _v_greyscale = new VarBool("greyscale", false);
+
+  _settings = new VarList("Visualization");
+  _settings->addChild(_v_enabled);
+  _settings->addChild(_v_image);
+  _settings->addChild(_v_greyscale);
+}
+
+PluginDistribute::~PluginDistribute() {}
+
+VarList *PluginDistribute::getSettings() { return _settings; }
+
+string PluginDistribute::getName() { return "Visualization"; }
+
+void PluginDistribute::DrawCameraImage(FrameData *data,
+                                       VisualizationFrame *vis_frame) {
+  // if converting entire image then blanking is not needed
+  const ColorFormat source_format = data->video.getColorFormat();
+  if (source_format == COLOR_RGB8) {
+    // plain copy of data
+    memcpy(vis_frame->data.getData(), data->video.getData(),
+           data->video.getNumBytes());
+  } else if (source_format == COLOR_YUV422_UYVY) {
+    Conversions::uyvy2rgb(
+        data->video.getData(),
+        reinterpret_cast<unsigned char *>(vis_frame->data.getData()),
+        data->video.getWidth(), data->video.getHeight());
+  } else {
+    // blank it:
+    vis_frame->data.fillBlack();
+    fprintf(stderr, "Unable to visualize color format: %s\n",
+            Colors::colorFormatToString(source_format).c_str());
+    fprintf(stderr, "Currently supported are rgb8 and yuv422 (UYVY).\n");
+    fprintf(stderr, "(Feel free to add more conversions to %s in %s).\n",
+            __FUNCTION__, __FILE__);
+  }
+  if (_v_greyscale->getBool() == true) {
+    unsigned int n = vis_frame->data.getNumPixels();
+    rgb *vis_ptr = vis_frame->data.getPixelData();
+    rgb color;
+    for (unsigned int i = 0; i < n; i++) {
+      color = vis_ptr[i];
+      color.r = color.g = color.b = ((color.r + color.g + color.b) / 3);
+      vis_ptr[i] = color;
+    }
+  }
+}
+
+ProcessResult PluginDistribute::process(FrameData *data,
+                                        RenderOptions *options) {
+  if (data == 0)
+    return ProcessingFailed;
+
+  for(int i=0;i<captureSplitters.size();i++) {
+    captureSplitters[i]->onNewFrame(&data->video);
+  }
+
+  VisualizationFrame *vis_frame =
+      reinterpret_cast<VisualizationFrame *>(data->map.get("vis_frame"));
+  if (vis_frame == 0) {
+    vis_frame = reinterpret_cast<VisualizationFrame *>(
+        data->map.insert("vis_frame", new VisualizationFrame()));
+  }
+
+  if (_v_enabled->getBool()) {
+    // check video data...
+    if (data->video.getWidth() == 0 || data->video.getHeight() == 0) {
+      // there is no valid video data
+      // mark visualization data as invalid
+      vis_frame->valid = false;
+      return ProcessingOk;
+    } else {
+      // allocate visualization frame accordingly:
+      vis_frame->data.allocate(data->video.getWidth(), data->video.getHeight());
+    }
+
+    // Draw camera image
+    if (_v_image->getBool()) {
+      DrawCameraImage(data, vis_frame);
+    } else {
+      vis_frame->data.fillBlack();
+    }
+
+    vis_frame->valid = true;
+  } else {
+    vis_frame->valid = false;
+  }
+  return ProcessingOk;
+}

--- a/src/app/plugins/plugin_distribute.cpp
+++ b/src/app/plugins/plugin_distribute.cpp
@@ -14,6 +14,7 @@
 //========================================================================
 
 #include "plugin_distribute.h"
+#include <opencv2/opencv.hpp>
 
 PluginDistribute::PluginDistribute(FrameBuffer *_buffer, vector<CaptureSplitter *> captureSplitters)
     : VisionPlugin(_buffer),
@@ -47,6 +48,10 @@ void PluginDistribute::DrawCameraImage(FrameData *data,
         data->video.getData(),
         reinterpret_cast<unsigned char *>(vis_frame->data.getData()),
         data->video.getWidth(), data->video.getHeight());
+  } else if (source_format==COLOR_RAW8) {
+    cv::Mat src(data->video.getHeight(), data->video.getWidth(), CV_8UC1, data->video.getData());
+    cv::Mat dst(data->video.getHeight(), data->video.getWidth(), CV_8UC3, vis_frame->data.getData());
+    cvtColor(src, dst, cv::COLOR_BayerBG2RGB);
   } else {
     // blank it:
     vis_frame->data.fillBlack();

--- a/src/app/plugins/plugin_distribute.h
+++ b/src/app/plugins/plugin_distribute.h
@@ -1,0 +1,43 @@
+//========================================================================
+//  This software is free: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License Version 3,
+//  as published by the Free Software Foundation.
+//
+//  This software is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  Version 3 in the file COPYING that came with this distribution.
+//  If not, see <http://www.gnu.org/licenses/>.
+//========================================================================
+
+#pragma once
+
+#include <visionplugin.h>
+#include <captureinterface.h>
+#include "image.h"
+#include "plugin_visualize.h"
+#include "capture_splitter.h"
+
+class PluginDistribute : public VisionPlugin {
+protected:
+  VarList *_settings;
+  VarBool *_v_enabled;
+  VarBool *_v_image;
+  VarBool *_v_greyscale;
+
+  std::vector<CaptureSplitter*> captureSplitters;
+
+  void DrawCameraImage(FrameData *data, VisualizationFrame *vis_frame);
+
+public:
+  PluginDistribute(FrameBuffer *_buffer, vector<CaptureSplitter *> captureSplitters);
+
+  ~PluginDistribute();
+
+  virtual ProcessResult process(FrameData *data, RenderOptions *options);
+  virtual VarList *getSettings();
+  virtual string getName();
+};

--- a/src/app/plugins/plugin_distribute.h
+++ b/src/app/plugins/plugin_distribute.h
@@ -30,7 +30,7 @@ protected:
 
   std::vector<CaptureSplitter*> captureSplitters;
 
-  void DrawCameraImage(FrameData *data, VisualizationFrame *vis_frame);
+  void drawCameraImage(FrameData *data, VisualizationFrame *vis_frame);
 
 public:
   PluginDistribute(FrameBuffer *_buffer, vector<CaptureSplitter *> captureSplitters);

--- a/src/app/plugins/plugin_visualize.cpp
+++ b/src/app/plugins/plugin_visualize.cpp
@@ -20,6 +20,7 @@
 //========================================================================
 #include "plugin_visualize.h"
 #include <sobel.h>
+#include <opencv2/opencv.hpp>
 
 namespace {
 typedef CameraParameters::AdditionalCalibrationInformation AddnlCalibInfo;
@@ -83,6 +84,10 @@ void PluginVisualize::DrawCameraImage(
         data->video.getData(),
         reinterpret_cast<unsigned char*>(vis_frame->data.getData()),
         data->video.getWidth(), data->video.getHeight());
+  } else if (source_format==COLOR_RAW8) {
+    cv::Mat src(data->video.getWidth(), data->video.getHeight(), CV_8UC1, data->video.getData());
+    cv::Mat dst(data->video.getWidth(), data->video.getHeight(), CV_8UC3, vis_frame->data.getData());
+    cvtColor(src, dst, cv::COLOR_BayerBG2BGR);
   } else {
     //blank it:
     vis_frame->data.fillBlack();

--- a/src/app/stacks/DistributorStack.cpp
+++ b/src/app/stacks/DistributorStack.cpp
@@ -19,6 +19,6 @@
 
 DistributorStack::DistributorStack(RenderOptions *_opts, FrameBuffer *_fb,
                                    vector<CaptureSplitter *> captureSplitters)
-    : VisionStack("RoboCup Image Distributor", _opts) {
+    : VisionStack(_opts) {
   stack.push_back(new PluginDistribute(_fb, std::move(captureSplitters)));
 }

--- a/src/app/stacks/DistributorStack.cpp
+++ b/src/app/stacks/DistributorStack.cpp
@@ -1,0 +1,24 @@
+//========================================================================
+//  This software is free: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License Version 3,
+//  as published by the Free Software Foundation.
+//
+//  This software is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  Version 3 in the file COPYING that came with this distribution.
+//  If not, see <http://www.gnu.org/licenses/>.
+//========================================================================
+
+#include "DistributorStack.h"
+#include <plugins/plugin_distribute.h>
+#include <utility>
+
+DistributorStack::DistributorStack(RenderOptions *_opts, FrameBuffer *_fb,
+                                   vector<CaptureSplitter *> captureSplitters)
+    : VisionStack("RoboCup Image Distributor", _opts) {
+  stack.push_back(new PluginDistribute(_fb, std::move(captureSplitters)));
+}

--- a/src/app/stacks/DistributorStack.h
+++ b/src/app/stacks/DistributorStack.h
@@ -1,0 +1,24 @@
+//========================================================================
+//  This software is free: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License Version 3,
+//  as published by the Free Software Foundation.
+//
+//  This software is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  Version 3 in the file COPYING that came with this distribution.
+//  If not, see <http://www.gnu.org/licenses/>.
+//========================================================================
+
+#pragma once
+
+#include "visionstack.h"
+#include <capture_splitter.h>
+
+class DistributorStack : public VisionStack {
+public:
+  DistributorStack(RenderOptions *_opts, FrameBuffer *_fb, vector<CaptureSplitter*> captureSplitters);
+};

--- a/src/app/stacks/multistack_robocup_ssl.cpp
+++ b/src/app/stacks/multistack_robocup_ssl.cpp
@@ -22,7 +22,7 @@
 #include "capture_splitter.h"
 #include "DistributorStack.h"
 
-MultiStackRoboCupSSL::MultiStackRoboCupSSL(RenderOptions *_opts) :
+MultiStackRoboCupSSL::MultiStackRoboCupSSL(RenderOptions *_opts, int num_normal_camera_threads) :
     MultiVisionStack("RoboCup SSL Multi-Cam",_opts),
     ds_udp_server_new(NULL),
     ds_udp_server_old(NULL) {
@@ -86,11 +86,11 @@ MultiStackRoboCupSSL::MultiStackRoboCupSSL(RenderOptions *_opts) :
       *global_field);
 
   //add parameter for number of cameras
-  int numNormalCameraThreads = 4;
-  createThreads(numNormalCameraThreads + 1);
+  int num_threads = num_normal_camera_threads + 1;
+  createThreads(num_threads);
   std::vector<CaptureSplitter*> captureSplitters;
-  captureSplitters.resize((unsigned long) numNormalCameraThreads);
-  for (unsigned int i = 0; i < numNormalCameraThreads;i++) {
+  captureSplitters.resize((unsigned long) num_normal_camera_threads);
+  for (unsigned int i = 0; i < num_normal_camera_threads;i++) {
     //NOTE: if modified to put different stacks in cameras, please
     //      update the plugin_colorcalib.cpp code to safely reallocate and copy their
     //      data instead of assuming that format and size is uniform across
@@ -113,11 +113,11 @@ MultiStackRoboCupSSL::MultiStackRoboCupSSL(RenderOptions *_opts) :
     captureSplitters[i] = dynamic_cast<CaptureSplitter*>(threads[i]->getCaptureSplitter());
   }
 
-  threads[numNormalCameraThreads]->setFrameBuffer(new FrameBuffer(5));
-  threads[numNormalCameraThreads]->setStack(
+  threads[num_normal_camera_threads]->setFrameBuffer(new FrameBuffer(5));
+  threads[num_normal_camera_threads]->setStack(
           new DistributorStack(
                   _opts,
-                  threads[numNormalCameraThreads]->getFrameBuffer(),
+                  threads[num_normal_camera_threads]->getFrameBuffer(),
                   captureSplitters));
 }
 

--- a/src/app/stacks/multistack_robocup_ssl.cpp
+++ b/src/app/stacks/multistack_robocup_ssl.cpp
@@ -95,7 +95,7 @@ MultiStackRoboCupSSL::MultiStackRoboCupSSL(RenderOptions *_opts, int num_normal_
     //      update the plugin_colorcalib.cpp code to safely reallocate and copy their
     //      data instead of assuming that format and size is uniform across
     //      cameras -- added when LUTs became aware of other cameras (Zavesky, 2/16)
-    threads[i]->setFrameBuffer(new FrameBuffer(5));
+    threads[i]->setFrameBuffer(new FrameBuffer(3));
     threads[i]->setStack(
         new StackRoboCupSSL(
             _opts,threads[i]->getFrameBuffer(),
@@ -113,7 +113,7 @@ MultiStackRoboCupSSL::MultiStackRoboCupSSL(RenderOptions *_opts, int num_normal_
     captureSplitters[i] = dynamic_cast<CaptureSplitter*>(threads[i]->getCaptureSplitter());
   }
 
-  threads[num_normal_camera_threads]->setFrameBuffer(new FrameBuffer(5));
+  threads[num_normal_camera_threads]->setFrameBuffer(new FrameBuffer(3));
   threads[num_normal_camera_threads]->setStack(
           new DistributorStack(
                   _opts,

--- a/src/app/stacks/multistack_robocup_ssl.cpp
+++ b/src/app/stacks/multistack_robocup_ssl.cpp
@@ -87,7 +87,7 @@ MultiStackRoboCupSSL::MultiStackRoboCupSSL(RenderOptions *_opts, int num_normal_
 
   //add parameter for number of cameras
   int num_threads = num_normal_camera_threads + 1;
-  createThreads(num_threads);
+  createThreads(num_threads, num_normal_camera_threads);
   std::vector<CaptureSplitter*> captureSplitters;
   captureSplitters.resize((unsigned long) num_normal_camera_threads);
   for (unsigned int i = 0; i < num_normal_camera_threads;i++) {

--- a/src/app/stacks/multistack_robocup_ssl.h
+++ b/src/app/stacks/multistack_robocup_ssl.h
@@ -54,7 +54,7 @@ class MultiStackRoboCupSSL : public QObject, public MultiVisionStack {
   // UDP Server for Double-Sized field, old protobuf format.
   RoboCupSSLServer * ds_udp_server_old;
   public:
-  MultiStackRoboCupSSL(RenderOptions *_opts);
+  MultiStackRoboCupSSL(RenderOptions *_opts, int num_normal_camera_threads);
   virtual string getSettingsFileName();
   virtual ~MultiStackRoboCupSSL();
   public slots:

--- a/src/app/stacks/multistack_robocup_ssl.h
+++ b/src/app/stacks/multistack_robocup_ssl.h
@@ -54,7 +54,7 @@ class MultiStackRoboCupSSL : public QObject, public MultiVisionStack {
   // UDP Server for Double-Sized field, old protobuf format.
   RoboCupSSLServer * ds_udp_server_old;
   public:
-  MultiStackRoboCupSSL(RenderOptions * _opts, int cameras);
+  MultiStackRoboCupSSL(RenderOptions *_opts);
   virtual string getSettingsFileName();
   virtual ~MultiStackRoboCupSSL();
   public slots:

--- a/src/app/stacks/multivisionstack.cpp
+++ b/src/app/stacks/multivisionstack.cpp
@@ -48,7 +48,7 @@ string MultiVisionStack::getSettingsFileName() {
 
 void MultiVisionStack::createThreads(int number) {
   for (int i=0;i<number;i++) {
-    threads.push_back(new CaptureThread(i));
+    threads.push_back(new CaptureThread(i%4));
   }
 }
 

--- a/src/app/stacks/multivisionstack.cpp
+++ b/src/app/stacks/multivisionstack.cpp
@@ -46,9 +46,9 @@ string MultiVisionStack::getSettingsFileName() {
   return name;
 }
 
-void MultiVisionStack::createThreads(int number) {
+void MultiVisionStack::createThreads(int number, int max_cameras) {
   for (int i=0;i<number;i++) {
-    threads.push_back(new CaptureThread(i%4));
+    threads.push_back(new CaptureThread(i%max_cameras));
   }
 }
 

--- a/src/app/stacks/multivisionstack.h
+++ b/src/app/stacks/multivisionstack.h
@@ -44,7 +44,7 @@ public:
   RenderOptions * opts;
   VarList * settings;
 protected:
-    void createThreads(int number);
+    void createThreads(int number, int max_cameras);
 public:
     MultiVisionStack(string _name, RenderOptions * _opts);
     virtual ~MultiVisionStack();

--- a/src/app/stacks/stack_robocup_ssl.cpp
+++ b/src/app/stacks/stack_robocup_ssl.cpp
@@ -34,7 +34,7 @@ StackRoboCupSSL::StackRoboCupSSL(
     RoboCupSSLServer * ds_udp_server_new,
     RoboCupSSLServer * ds_udp_server_old,
     string cam_settings_filename) :
-    VisionStack("RoboCup Image Processing",_opts),
+    VisionStack(_opts),
     _camera_id(camera_id),
     _cam_settings_filename(cam_settings_filename),
     global_field(_global_field),

--- a/src/app/stacks/visionstack.cpp
+++ b/src/app/stacks/visionstack.cpp
@@ -20,11 +20,8 @@
 //========================================================================
 #include "visionstack.h"
 
-VisionStack::VisionStack(string _name, RenderOptions * _opts) {
-  name=_name;
+VisionStack::VisionStack(RenderOptions * _opts) {
   opts=_opts;
-  //counter_proc=0.0;
-  //counter_post_proc=0.0;
   settings=new VarList("Global");
 }
 
@@ -32,59 +29,24 @@ VisionStack::~VisionStack() {
   delete settings;
 }
 
-string VisionStack::getName() {
-  return name;
-}
-
 VarList * VisionStack::getSettings() {
   return settings;
 }
 
-string VisionStack::getSettingsFileName() {
-  //this can be done dynamically based on camera-id's etc...
-  return name;
-}
-
 void VisionStack::process(FrameData * data) {
-  double a=0.0;
-  double b=0.0;
-  unsigned int n=stack.size();
-  VisionPlugin * p;
-  double total=0.0;
-  bool show_timing = false;
-  if (show_timing) printf("----------\n");
-  for (unsigned int i=0;i<n;i++) {
-    p=stack[i];
+  for (auto p : stack) {
     p->lock();
-    a=GetTimeSec();
     p->process(data,opts);
-    b=GetTimeSec();
-    p->setTimeProcessing(b-a);
-    total+=(p->getTimeProcessing());
-    if (show_timing) {
-      printf("Plugin %s: %fms\n",p->getName().c_str(),  p->getTimeProcessing() * 1000.0);
-    }
     p->unlock();
   }
-  if (show_timing) printf("Total time: %fms\n",total * 1000.0);
-  //counter_proc+=1.0;
 }
 
 void VisionStack::postProcess(FrameData * data) {
-  unsigned int n=stack.size();
-  double a=0.0;
-  double b=0.0;
-  VisionPlugin * p;
-  for (unsigned int i=0;i<n;i++) {
-    p=stack[i];
+  for (auto p : stack) {
     p->lock();
-    a=GetTimeSec();
     p->postProcess(data,opts);
-    b=GetTimeSec();
-    p->setTimePostProcessing(b-a);
     p->unlock();
   }
-  //counter_post_proc+=1.0;
 }
 
 void VisionStack::updateTimingStatistics() {

--- a/src/app/stacks/visionstack.h
+++ b/src/app/stacks/visionstack.h
@@ -33,19 +33,14 @@ using namespace std;
 */
 class VisionStack {
 protected:
-  string name;
   RenderOptions * opts;
   VarList * settings;
-  //double counter_proc;
-  //double counter_post_proc;
 public:
-    VisionStack(string _name, RenderOptions * _opts);
+    VisionStack(RenderOptions * _opts);
     virtual ~VisionStack();
     vector<VisionPlugin *> stack;
 
     VarList * getSettings();
-    virtual string getName();
-    virtual string getSettingsFileName();
 
     void process(FrameData * data);
     void postProcess(FrameData * data);

--- a/src/shared/CMakeLists.txt.inc
+++ b/src/shared/CMakeLists.txt.inc
@@ -15,6 +15,7 @@ include_directories(${shared_dir}/vartypes/xml)
 set (SHARED_SRCS
 	${shared_dir}/capture/capturev4l.cpp
 	${shared_dir}/capture/capturefromfile.cpp
+	${shared_dir}/capture/capture_splitter.cpp
 	${shared_dir}/capture/capture_generator.cpp
 	${shared_dir}/capture/captureinterface.cpp
 
@@ -101,6 +102,7 @@ set (SHARED_HEADERS
 	${shared_dir}/capture/capturev4l.h
 	${shared_dir}/capture/capturefromfile.h
   ${shared_dir}/capture/capture_generator.h
+    ${shared_dir}/capture/capture_splitter.h
 
 	${shared_dir}/cmpattern/cmpattern_team.h
 	${shared_dir}/cmpattern/cmpattern_teamdetector.h

--- a/src/shared/capture/capture_splitter.cpp
+++ b/src/shared/capture/capture_splitter.cpp
@@ -14,6 +14,7 @@
 //========================================================================
 
 #include "capture_splitter.h"
+#include <algorithm>
 
 #ifndef VDATA_NO_QT
 CaptureSplitter::CaptureSplitter(VarList * _settings, int default_camera_id, QObject * parent) : QObject(parent), CaptureInterface(_settings)
@@ -22,15 +23,34 @@ CaptureSplitter::CaptureSplitter(VarList * _settings) : CaptureInterface(_settin
 #endif
 {
   is_capturing=false;
-  camera_id = default_camera_id;
-  frame = new RawImage();
-  nextFrame = new RawImage();
-}
+  switch(default_camera_id)
+  {
+    case 0:
+    default:
+      settings->addChild(relative_height_offset = new VarDouble("Relative height offset", 0.0, 0.0, 1.0));
+      settings->addChild(relative_width_offset = new VarDouble("Relative width offset", 0.0, 0.0, 1.0));
+      break;
+    case 1:
+      settings->addChild(relative_height_offset = new VarDouble("Relative height offset", 0.4, 0.0, 1.0));
+      settings->addChild(relative_width_offset = new VarDouble("Relative width offset", 0.0, 0.0, 1.0));
+      break;
+    case 2:
+      settings->addChild(relative_height_offset = new VarDouble("Relative height offset", 0.0, 0.0, 1.0));
+      settings->addChild(relative_width_offset = new VarDouble("Relative width offset", 0.4, 0.0, 1.0));
+      break;
+    case 3:
+      settings->addChild(relative_height_offset = new VarDouble("Relative height offset", 0.4, 0.0, 1.0));
+      settings->addChild(relative_width_offset = new VarDouble("Relative width offset", 0.4, 0.0, 1.0));
+      break;
+  }
 
-CaptureSplitter::~CaptureSplitter()
-{
-  delete frame;
-  delete nextFrame;
+  if(default_camera_id < 4) {
+    settings->addChild(relative_height = new VarDouble("Relative height", 0.6, 0.0, 1.0));
+    settings->addChild(relative_width = new VarDouble("Relative width", 0.6, 0.0, 1.0));
+  } else {
+    settings->addChild(relative_height = new VarDouble("Relative height", 1.0, 0.0, 1.0));
+    settings->addChild(relative_width = new VarDouble("Relative width", 1.0, 0.0, 1.0));
+  }
 }
 
 bool CaptureSplitter::stopCapture()
@@ -45,6 +65,8 @@ void CaptureSplitter::cleanup()
   mutex.lock();
 #endif
   is_capturing=false;
+  full_image_arrived_mutex.unlock();
+  frame_processed_mutex.unlock();
 #ifndef VDATA_NO_QT
   mutex.unlock();
 #endif
@@ -57,6 +79,8 @@ bool CaptureSplitter::startCapture()
 #endif
 
   is_capturing = true;
+  full_image_arrived_mutex.try_lock();
+  frame_processed_mutex.try_lock();
 
 #ifndef VDATA_NO_QT
   mutex.unlock();
@@ -64,22 +88,53 @@ bool CaptureSplitter::startCapture()
   return true;
 }
 
-bool CaptureSplitter::copyAndConvertFrame(const RawImage & src, RawImage & target)
-{
+bool CaptureSplitter::copyAndConvertFrame(const RawImage &src, RawImage &target) {
 #ifndef VDATA_NO_QT
   mutex.lock();
 #endif
 
-
-  if(src.getWidth() == 0 || src.getHeight() == 0)
-  {
+  if (src.getWidth() == 0 || src.getHeight() == 0) {
 #ifndef VDATA_NO_QT
     mutex.unlock();
 #endif
     return false;
   }
+  target.setTime(src.getTime());
 
-  target.deepCopyFromRawImage(src, true);
+  // make sure we use values from 0 to 1
+  double rel_height_offset = std::min(1.0, std::max(0.0, relative_height_offset->getDouble()));
+  double rel_height = std::min(1.0, std::max(0.0, relative_height->getDouble()));
+  double rel_width_offset = std::min(1.0, std::max(0.0, relative_width_offset->getDouble()));
+  double rel_width = std::min(1.0, std::max(0.0, relative_width->getDouble()));
+
+  // make sure we keep within the src image
+  rel_height = std::min(rel_height, 1 - rel_height_offset);
+  rel_width = std::min(rel_width, 1 - rel_width_offset);
+
+  // calculate offset in src image
+  int height_offset = (int) (src.getHeight() * rel_height_offset);
+  int width_offset = (int) (src.getWidth() * rel_width_offset);
+
+  // calculate dimensions of target image
+  int height = (int) (src.getHeight() * rel_height);
+  int width = (int) (src.getWidth() * rel_width);
+
+  // for some reason, the image gets screwed when the width is not a multiple of 4
+  width -= width % 4;
+
+  // allocate target image
+  target.allocate(src.getColorFormat(), width, height);
+
+  // copy data
+  unsigned char *data_dest = target.getData();
+  unsigned char *data_src = src.getData();
+  auto pixel_size = (size_t) RawImage::computeImageSize(target.getColorFormat(), 1);
+  for (int i = 0; i < height; i++) {
+    memcpy(
+            data_dest + i * width * pixel_size,
+            data_src + ((i + height_offset) * src.getWidth() + width_offset) * pixel_size,
+            pixel_size * width);
+  }
 
 #ifndef VDATA_NO_QT
   mutex.unlock();
@@ -93,18 +148,23 @@ RawImage CaptureSplitter::getFrame()
    mutex.lock();
 #endif
 
-  frameMutex.lock();
-  frame->deepCopyFromRawImage(*nextFrame, true);
-  frameMutex.unlock();
+  full_image_arrived_mutex.lock();
+
+  RawImage frame;
+  if(full_image != nullptr)
+  {
+    frame = *full_image;
+  }
 
 #ifndef VDATA_NO_QT
   mutex.unlock();
 #endif
-  return *frame;
+  return frame;
 }
 
 void CaptureSplitter::releaseFrame()
 {
+  frame_processed_mutex.unlock();
 }
 
 string CaptureSplitter::getCaptureMethodName() const
@@ -112,10 +172,17 @@ string CaptureSplitter::getCaptureMethodName() const
   return "Splitter";
 }
 
-void CaptureSplitter::onNewFrame(RawImage* frame)
+void CaptureSplitter::onNewFrame(RawImage* image)
 {
-  // TODO split image
-  frameMutex.lock();
-  nextFrame->deepCopyFromRawImage(*frame, true);
-  frameMutex.unlock();
+  if(isCapturing()) {
+    full_image = image;
+    full_image_arrived_mutex.unlock();
+  }
+}
+
+void CaptureSplitter::waitUntilFrameProcessed()
+{
+  if(isCapturing()) {
+	frame_processed_mutex.lock();
+  }
 }

--- a/src/shared/capture/capture_splitter.cpp
+++ b/src/shared/capture/capture_splitter.cpp
@@ -158,7 +158,7 @@ bool CaptureSplitter::copyAndConvertFrame(const RawImage &src, RawImage &target)
 
   target.ensure_allocation(ColorFormat::COLOR_RGB8, width, height);
 
-  if(image_buffer->getData() == nullptr)
+  if(target.getData() == nullptr)
   {
     std::cout << "Could not allocate image. Target color format '" << Colors::colorFormatToString(target.getColorFormat()) << "' not supported?" << std::endl;
 #ifndef VDATA_NO_QT
@@ -167,11 +167,17 @@ bool CaptureSplitter::copyAndConvertFrame(const RawImage &src, RawImage &target)
     return false;
   }
 
-  if(image_buffer->getColorFormat() == ColorFormat::COLOR_RAW8) {
-  cv::Mat srcMat(height, width, CV_8UC1, data_buf);
-  cv::Mat dstMat(height, width, CV_8UC3, target.getData());
-  cvtColor(srcMat, dstMat, cv::COLOR_BayerBG2RGB);
-  } else if(image_buffer->getColorFormat() != ColorFormat::COLOR_RGB8)
+  if(image_buffer->getColorFormat() == ColorFormat::COLOR_RAW8)
+  {
+    cv::Mat srcMat(height, width, CV_8UC1, data_buf);
+    cv::Mat dstMat(height, width, CV_8UC3, target.getData());
+    cvtColor(srcMat, dstMat, cv::COLOR_BayerBG2RGB);
+  }
+  else if(target.getColorFormat() == ColorFormat::COLOR_RGB8)
+  {
+    memcpy(target.getData(), image_buffer->getData(), static_cast<size_t>(image_buffer->getNumBytes()));
+  }
+  else
   {
     std::cout << "Unsupported image format: " << Colors::colorFormatToString(image_buffer->getColorFormat()) << std::endl;
 #ifndef VDATA_NO_QT

--- a/src/shared/capture/capture_splitter.cpp
+++ b/src/shared/capture/capture_splitter.cpp
@@ -127,8 +127,11 @@ bool CaptureSplitter::copyAndConvertFrame(const RawImage &src, RawImage &target)
   int height = (int) (src.getHeight() * rel_height);
   int width = (int) (src.getWidth() * rel_width);
 
-  // for some reason, the image gets screwed when the width is not a multiple of 4
-  width -= width % 4;
+  // make sure to not cut through the bayer pattern in the raw image
+  height_offset -= height_offset % 2;
+  width_offset -= width_offset % 2;
+  width -= width % 2;
+  height -= height % 2;
 
   // allocate target image
   image_buffer->ensure_allocation(src.getColorFormat(), width, height);

--- a/src/shared/capture/capture_splitter.cpp
+++ b/src/shared/capture/capture_splitter.cpp
@@ -1,0 +1,121 @@
+//========================================================================
+//  This software is free: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License Version 3,
+//  as published by the Free Software Foundation.
+//
+//  This software is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  Version 3 in the file COPYING that came with this distribution.
+//  If not, see <http://www.gnu.org/licenses/>.
+//========================================================================
+
+#include "capture_splitter.h"
+
+#ifndef VDATA_NO_QT
+CaptureSplitter::CaptureSplitter(VarList * _settings, int default_camera_id, QObject * parent) : QObject(parent), CaptureInterface(_settings)
+#else
+CaptureSplitter::CaptureSplitter(VarList * _settings) : CaptureInterface(_settings)
+#endif
+{
+  is_capturing=false;
+  camera_id = default_camera_id;
+  frame = new RawImage();
+  nextFrame = new RawImage();
+}
+
+CaptureSplitter::~CaptureSplitter()
+{
+  delete frame;
+  delete nextFrame;
+}
+
+bool CaptureSplitter::stopCapture()
+{
+  cleanup();
+  return true;
+}
+
+void CaptureSplitter::cleanup()
+{
+#ifndef VDATA_NO_QT
+  mutex.lock();
+#endif
+  is_capturing=false;
+#ifndef VDATA_NO_QT
+  mutex.unlock();
+#endif
+}
+
+bool CaptureSplitter::startCapture()
+{
+#ifndef VDATA_NO_QT
+  mutex.lock();
+#endif
+
+  is_capturing = true;
+
+#ifndef VDATA_NO_QT
+  mutex.unlock();
+#endif
+  return true;
+}
+
+bool CaptureSplitter::copyAndConvertFrame(const RawImage & src, RawImage & target)
+{
+#ifndef VDATA_NO_QT
+  mutex.lock();
+#endif
+
+
+  if(src.getWidth() == 0 || src.getHeight() == 0)
+  {
+#ifndef VDATA_NO_QT
+    mutex.unlock();
+#endif
+    return false;
+  }
+
+  target.deepCopyFromRawImage(src, true);
+
+#ifndef VDATA_NO_QT
+  mutex.unlock();
+#endif
+  return true;
+}
+
+RawImage CaptureSplitter::getFrame()
+{
+#ifndef VDATA_NO_QT
+   mutex.lock();
+#endif
+
+  frameMutex.lock();
+  frame->deepCopyFromRawImage(*nextFrame, true);
+  frameMutex.unlock();
+
+#ifndef VDATA_NO_QT
+  mutex.unlock();
+#endif
+  return *frame;
+}
+
+void CaptureSplitter::releaseFrame()
+{
+}
+
+string CaptureSplitter::getCaptureMethodName() const
+{
+  return "Splitter";
+}
+
+void CaptureSplitter::onNewFrame(RawImage* frame)
+{
+  // TODO split image
+  frameMutex.lock();
+  nextFrame->deepCopyFromRawImage(*frame, true);
+  frameMutex.unlock();
+}

--- a/src/shared/capture/capture_splitter.cpp
+++ b/src/shared/capture/capture_splitter.cpp
@@ -87,9 +87,8 @@ bool CaptureSplitter::startCapture()
   mutex.lock();
 #endif
 
-  is_capturing = true;
   full_image_arrived_mutex.try_lock();
-  frame_processed_mutex.try_lock();
+  is_capturing = true;
 
 #ifndef VDATA_NO_QT
   mutex.unlock();
@@ -225,6 +224,6 @@ void CaptureSplitter::onNewFrame(RawImage* image)
 void CaptureSplitter::waitUntilFrameProcessed()
 {
   if(isCapturing()) {
-	frame_processed_mutex.lock();
+	  frame_processed_mutex.lock();
   }
 }

--- a/src/shared/capture/capture_splitter.h
+++ b/src/shared/capture/capture_splitter.h
@@ -50,6 +50,7 @@ protected:
   VarDouble* relative_height;
 
   RawImage* full_image;
+  RawImage* image_buffer;
   std::mutex full_image_arrived_mutex;
   std::mutex frame_processed_mutex;
 
@@ -59,7 +60,7 @@ public:
 #else
   CaptureSplitter(VarList * _settings);
 #endif
-  ~CaptureSplitter() override = default;
+  ~CaptureSplitter() override;
 
   bool startCapture() override;
   bool stopCapture() override;

--- a/src/shared/capture/capture_splitter.h
+++ b/src/shared/capture/capture_splitter.h
@@ -1,0 +1,74 @@
+//========================================================================
+//  This software is free: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License Version 3,
+//  as published by the Free Software Foundation.
+//
+//  This software is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  Version 3 in the file COPYING that came with this distribution.
+//  If not, see <http://www.gnu.org/licenses/>.
+//========================================================================
+
+#pragma once
+
+#include "captureinterface.h"
+#include "VarTypes.h"
+#include <mutex>
+
+#ifndef VDATA_NO_QT
+  #include <QMutex>
+#else
+  #include <pthread.h>
+#endif
+
+
+#ifndef VDATA_NO_QT
+//if using QT, inherit QObject as a base
+class CaptureSplitter : public QObject, public CaptureInterface
+#else
+class CaptureSplitter : public CaptureInterface
+#endif
+{
+#ifndef VDATA_NO_QT
+  Q_OBJECT
+/*   public slots: */
+  protected:
+  QMutex mutex;
+  public:
+#endif
+
+protected:
+  bool is_capturing;
+  int camera_id;
+
+  RawImage* frame;
+  RawImage* nextFrame;
+  std::mutex frameMutex;
+
+public:
+#ifndef VDATA_NO_QT
+  CaptureSplitter(VarList * _settings, int default_camera_id, QObject * parent=nullptr);
+#else
+  CaptureSplitter(VarList * _settings);
+#endif
+  ~CaptureSplitter() override;
+
+  bool startCapture() override;
+  bool stopCapture() override;
+  bool isCapturing() override { return is_capturing; };
+  
+  RawImage getFrame() override;
+  void releaseFrame() override;
+   
+  void cleanup();
+
+  bool copyAndConvertFrame(const RawImage & src, RawImage & target) override;
+  string getCaptureMethodName() const override;
+
+  void onNewFrame(RawImage* frame);
+};
+

--- a/src/shared/capture/capture_splitter.h
+++ b/src/shared/capture/capture_splitter.h
@@ -43,11 +43,15 @@ class CaptureSplitter : public CaptureInterface
 
 protected:
   bool is_capturing;
-  int camera_id;
 
-  RawImage* frame;
-  RawImage* nextFrame;
-  std::mutex frameMutex;
+  VarDouble* relative_height_offset;
+  VarDouble* relative_width_offset;
+  VarDouble* relative_width;
+  VarDouble* relative_height;
+
+  RawImage* full_image;
+  std::mutex full_image_arrived_mutex;
+  std::mutex frame_processed_mutex;
 
 public:
 #ifndef VDATA_NO_QT
@@ -55,7 +59,7 @@ public:
 #else
   CaptureSplitter(VarList * _settings);
 #endif
-  ~CaptureSplitter() override;
+  ~CaptureSplitter() override = default;
 
   bool startCapture() override;
   bool stopCapture() override;
@@ -69,6 +73,7 @@ public:
   bool copyAndConvertFrame(const RawImage & src, RawImage & target) override;
   string getCaptureMethodName() const override;
 
-  void onNewFrame(RawImage* frame);
+  void onNewFrame(RawImage* image);
+  void waitUntilFrameProcessed();
 };
 

--- a/src/shared/util/rawimage.cpp
+++ b/src/shared/util/rawimage.cpp
@@ -157,6 +157,9 @@ int RawImage::computeImageSize(ColorFormat fmt, int pixelCount)
     case COLOR_YUV411: return pixelCount*3/2;
     case COLOR_MONO8: return pixelCount;
     case COLOR_MONO16: return pixelCount*2;
+    case COLOR_RAW8: return pixelCount;
+    case COLOR_RAW16: return pixelCount*2;
+    case COLOR_RAW32: return pixelCount*4;
     default:
     return 0;
   }


### PR DESCRIPTION
Resolves #116 

 * Add Distributor stack that captures an image and distributes it to the splitters
 * Add Splitter capture which cuts a part of the images from the distributor and applies the default vision stacks on the resulting image
 * Reduce the buffer size for capture to visualization transmission to reduce latency, always read the latest element from buffer
 * Add CLI parameter to set the number of camera threads
