### PR TITLE
Performance measurement

### DIFF
--- a/src/app/capture_thread.cpp
+++ b/src/app/capture_thread.cpp
@@ -35,6 +35,7 @@ CaptureThread::CaptureThread(int cam_id)
   control->addChild( (VarType*) (c_stop   = new VarTrigger("stop capture","Stop")));
   control->addChild( (VarType*) (c_reset  = new VarTrigger("reset bus","Reset")));
   control->addChild( (VarType*) (c_auto_refresh= new VarBool("auto refresh params",true)));
+  // timings should only be printed on demand for a short period of time by temporally activating this flag
   control->addChild( (VarType*) (c_print_timings = new VarBool("print timings",false)));
   control->addChild( (VarType*) (c_refresh= new VarTrigger("re-read params","Refresh")));
   control->addChild( (VarType*) (captureModule= new VarStringEnum("Capture Module","None")));

--- a/src/app/capture_thread.cpp
+++ b/src/app/capture_thread.cpp
@@ -21,6 +21,7 @@
 
 #include "capture_thread.h"
 #include <capture_splitter.h>
+#include <iostream>
 #include <iomanip>
 
 CaptureThread::CaptureThread(int cam_id)

--- a/src/app/capture_thread.h
+++ b/src/app/capture_thread.h
@@ -99,6 +99,7 @@ protected:
   VarTrigger * c_reset;
   VarTrigger * c_refresh;
   VarBool * c_auto_refresh;
+  VarBool * c_print_timings;
   VarStringEnum * captureModule;
   Timer timer;
 

--- a/src/app/stacks/visionstack.cpp
+++ b/src/app/stacks/visionstack.cpp
@@ -19,10 +19,13 @@
 */
 //========================================================================
 #include "visionstack.h"
+#include <iomanip>
 
 VisionStack::VisionStack(RenderOptions * _opts) {
   opts=_opts;
   settings=new VarList("Global");
+  _v_print_timings = new VarBool("print stack timings", false);
+  settings->addChild(_v_print_timings);
 }
 
 VisionStack::~VisionStack() {
@@ -34,10 +37,26 @@ VarList * VisionStack::getSettings() {
 }
 
 void VisionStack::process(FrameData * data) {
-  for (auto p : stack) {
-    p->lock();
-    p->process(data,opts);
-    p->unlock();
+  if(_v_print_timings->getBool()) {
+    auto totalStart = std::chrono::steady_clock::now();
+    for (auto p : stack) {
+      p->lock();
+      auto start = std::chrono::steady_clock::now();
+      p->process(data,opts);
+      auto duration = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start);
+      std::cout << std::setw(23) << std::left << p->getName()
+                << std::setw(5) << std::right << duration.count() << " μs" << std::endl;
+      p->unlock();
+    }
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - totalStart);
+    std::cout << std::setw(23) << std::left << "All"
+              << std::setw(5) << std::right << duration.count() << " μs" << std::endl << std::endl;
+  } else {
+    for (auto p : stack) {
+      p->lock();
+      p->process(data,opts);
+      p->unlock();
+    }
   }
 }
 

--- a/src/app/stacks/visionstack.cpp
+++ b/src/app/stacks/visionstack.cpp
@@ -20,6 +20,7 @@
 //========================================================================
 #include "visionstack.h"
 #include <iomanip>
+#include <iostream>
 #include <chrono>
 
 VisionStack::VisionStack(RenderOptions * _opts) {

--- a/src/app/stacks/visionstack.cpp
+++ b/src/app/stacks/visionstack.cpp
@@ -26,6 +26,7 @@
 VisionStack::VisionStack(RenderOptions * _opts) {
   opts=_opts;
   settings=new VarList("Global");
+  // timings should only be printed on demand for a short period of time by temporally activating this flag
   _v_print_timings = new VarBool("print stack timings", false);
   settings->addChild(_v_print_timings);
 }

--- a/src/app/stacks/visionstack.cpp
+++ b/src/app/stacks/visionstack.cpp
@@ -20,6 +20,7 @@
 //========================================================================
 #include "visionstack.h"
 #include <iomanip>
+#include <chrono>
 
 VisionStack::VisionStack(RenderOptions * _opts) {
   opts=_opts;

--- a/src/app/stacks/visionstack.h
+++ b/src/app/stacks/visionstack.h
@@ -35,6 +35,7 @@ class VisionStack {
 protected:
   RenderOptions * opts;
   VarList * settings;
+  VarBool * _v_print_timings;
 public:
     VisionStack(RenderOptions * _opts);
     virtual ~VisionStack();

--- a/src/shared/capture/capturefromfile.cpp
+++ b/src/shared/capture/capturefromfile.cpp
@@ -44,8 +44,8 @@ CaptureFromFile::CaptureFromFile(VarList * _settings, int default_camera_id, QOb
   v_colorout->addItem(Colors::colorFormatToString(COLOR_YUV422_UYVY));
   v_colorout->addItem(Colors::colorFormatToString(COLOR_RAW8));
 
-  conversion_settings-> addChild(v_raw_width=new VarInt("raw width", 0));
-  conversion_settings-> addChild(v_raw_height=new VarInt("raw height", 0));
+  conversion_settings-> addChild(v_raw_width=new VarInt("raw width", 2448));
+  conversion_settings-> addChild(v_raw_height=new VarInt("raw height", 2048));
 
   //=======================CAPTURE SETTINGS==========================
   ostringstream convert;
@@ -117,6 +117,11 @@ bool CaptureFromFile::startCapture()
       int height(v_raw_height->get());
       if(getFileExtension(currentImage) == "RAW")
       {
+        if(width <= 0 || height <= 0)
+        {
+          std::cout << "Could not read image. Dimensions must be positive." << std::endl;
+          continue;
+        }
         std::ifstream file(currentImage, std::ios::binary );
         if(!file)
         {


### PR DESCRIPTION
I added an option to print several timings of image processing. I think this will also be useful for end users if the capture rate is low, to see where the bottleneck is.

The steady clock should have nearly no impact on the performance.