### PR TITLE
fix integer division in basler Timing

### DIFF
--- a/src/shared/capture/capture_basler.cpp
+++ b/src/shared/capture/capture_basler.cpp
@@ -187,7 +187,7 @@ RawImage CaptureBasler::getFrame() {
 	try {
 		timeval tv;
 		gettimeofday(&tv, 0);
-		img.setTime((double) tv.tv_sec + (tv.tv_usec / 1000000));
+		img.setTime((double) tv.tv_sec + (tv.tv_usec / 1000000.0));
 
 		// Keep grabbing in case of partial grabs
 		int fail_count = 0;


### PR DESCRIPTION
Fixes #149.

This time with no other changes. Note this was only tested on the PC with slightly different code  (see #150).