### PR TITLE
Camera calibration with OpenCV and checkerboard

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -22,8 +22,8 @@ AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: Yes
-BinPackArguments: true
-BinPackParameters: true
+BinPackArguments: false
+BinPackParameters: false
 BraceWrapping:
   AfterCaseLabel:  false
   AfterClass:      false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(Qt5Core REQUIRED)
 find_package(Qt5Widgets REQUIRED)
 find_package(Qt5OpenGL REQUIRED)
 # Note: Bluefox SDK is not compatible with some components of OpenCV. Take care when enabling more.
-find_package(OpenCV REQUIRED COMPONENTS core imgproc imgcodecs videoio)
+find_package(OpenCV REQUIRED COMPONENTS core imgproc imgcodecs videoio calib3d)
 
 include(src/shared/CMakeLists.txt.inc)
 
@@ -142,6 +142,7 @@ set (SRCS ${SRCS}
 
     src/app/gui/maskwidget.cpp
 	src/app/gui/automatedcolorcalibwidget.cpp
+	src/app/gui/camera_intrinsic_calib_widget.cpp
 	src/app/gui/cameracalibwidget.cpp
 	src/app/gui/colorpicker.cpp
 	src/app/gui/glLUTwidget.cpp
@@ -155,6 +156,7 @@ set (SRCS ${SRCS}
 
 	src/app/plugins/plugin_mask.cpp
 	src/app/plugins/plugin_cameracalib.cpp
+	src/app/plugins/plugin_camera_intrinsic_calib.cpp
 	src/app/plugins/plugin_colorcalib.cpp
 	src/app/plugins/plugin_colorthreshold.cpp
 	src/app/plugins/plugin_detect_balls.cpp
@@ -183,6 +185,7 @@ qt5_wrap_cpp (MOC_SRCS
 
 	src/app/gui/maskwidget.h
 	src/app/gui/automatedcolorcalibwidget.h
+	src/app/gui/camera_intrinsic_calib_widget.h
 	src/app/gui/cameracalibwidget.h
 	src/app/gui/glLUTwidget.h
 	src/app/gui/glwidget.h
@@ -201,8 +204,11 @@ qt5_wrap_cpp (MOC_SRCS
 	src/app/plugins/plugin_colorcalib.h
 	src/app/plugins/plugin_colorthreshold.h
 	src/app/plugins/plugin_auto_color_calibration.h
+	src/app/plugins/plugin_camera_intrinsic_calib.h
 
 	src/app/stacks/multistack_robocup_ssl.h
+
+	src/shared/util/camera_parameters.h
 
 	${OPTIONAL_HEADERS}
 )

--- a/src/app/gui/camera_intrinsic_calib_widget.cpp
+++ b/src/app/gui/camera_intrinsic_calib_widget.cpp
@@ -1,0 +1,261 @@
+#include "camera_intrinsic_calib_widget.h"
+
+#include <QGroupBox>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+CameraIntrinsicCalibrationWidget::CameraIntrinsicCalibrationWidget(CameraParameters& camera_params)
+    : camera_params{camera_params} {
+  auto calibration_steps_layout = new QVBoxLayout;
+
+  // pattern configuration
+  {
+    auto pattern_config_layout = new QVBoxLayout;
+
+    // pattern select dropdown
+    {
+      auto pattern_selector_label = new QLabel(tr("Pattern type:"));
+
+      pattern_selector = new QComboBox();
+      pattern_selector->addItems({"Checkerboard", "Circles", "Asymmetric Circles"});
+
+      auto hbox = new QHBoxLayout;
+      hbox->addWidget(pattern_selector_label);
+      hbox->addWidget(pattern_selector);
+
+      pattern_config_layout->addLayout(hbox);
+    }
+
+    // pattern size config
+    {
+      auto grid_dimensions_label = new QLabel(tr("Grid Dimensions (width x height):"));
+
+      grid_width = new QSpinBox();
+      grid_width->setMinimum(2);
+      grid_width->setValue(camera_params.additional_calibration_information->grid_width->getInt());
+      connect(grid_width, SIGNAL(valueChanged(int)), this, SLOT(grid_width_changed(int)));
+      connect(camera_params.additional_calibration_information->grid_width, SIGNAL(hasChanged(VarType*)), this,
+              SLOT(grid_width_vartype_changed(VarType*)));
+
+      auto grid_dim_separator_label = new QLabel(tr("x"));
+
+      grid_height = new QSpinBox();
+      grid_height->setMinimum(2);
+      grid_height->setValue(camera_params.additional_calibration_information->grid_height->getInt());
+      connect(grid_height, SIGNAL(valueChanged(int)), this, SLOT(grid_height_changed(int)));
+      connect(camera_params.additional_calibration_information->grid_height, SIGNAL(hasChanged(VarType*)), this,
+              SLOT(grid_height_vartype_changed(VarType*)));
+
+      auto hbox = new QHBoxLayout;
+      hbox->addWidget(grid_dimensions_label);
+      hbox->addStretch();
+      hbox->addWidget(grid_width);
+      hbox->addWidget(grid_dim_separator_label);
+      hbox->addWidget(grid_height);
+
+      pattern_config_layout->addLayout(hbox);
+    }
+
+    auto pattern_config_groupbox = new QGroupBox(tr("Pattern Configuration"));
+    pattern_config_groupbox->setLayout(pattern_config_layout);
+
+    calibration_steps_layout->addWidget(pattern_config_groupbox);
+  }
+
+  // calibration instructions
+  {
+    auto calibration_instructions_layout = new QVBoxLayout;
+
+    calibration_instructions_layout->addWidget(
+        new QLabel(tr("Enable pattern detection here and enable display in the "
+                      "VisualizationPlugin.\n"
+                      "Verify that your pattern is detected properly.\nIf not "
+                      "detected double check the grid size and pattern type "
+                      "and verify that greyscale image has good contrast.")));
+
+    // detect pattern checkbox
+    {
+      auto label = new QLabel(tr("Detect Pattern"));
+
+      detect_pattern_checkbox = new QCheckBox();
+
+      auto hbox = new QHBoxLayout;
+      hbox->addWidget(label);
+      hbox->addWidget(detect_pattern_checkbox);
+
+      calibration_instructions_layout->addLayout(hbox);
+    }
+
+    // do corner subpixel correction checkbox
+    {
+      auto label = new QLabel(tr("Do Corner Subpixel Correction:"));
+
+      corner_subpixel_correction_checkbox = new QCheckBox();
+      corner_subpixel_correction_checkbox->setChecked(true);
+
+      auto hbox = new QHBoxLayout;
+      hbox->addWidget(label);
+      hbox->addWidget(corner_subpixel_correction_checkbox);
+
+      calibration_instructions_layout->addLayout(hbox);
+
+      calibration_instructions_layout->addWidget(
+          new QLabel(tr("When you can see a chessboard in the image, you can "
+                        "start capturing data.\n"
+                        "After each new sample, "
+                        "a calibration will be done and the "
+                        "calibration error will be shown as RMS.\n"
+                        "Make sure to capture enough images from different "
+                        "poses (like ~30).")));
+
+      capture_button = new QPushButton(tr("Capture"));
+      capture_button->setCheckable(true);
+      connect(capture_button, SIGNAL(clicked()), this, SLOT(updateConfigurationEnabled()));
+      calibration_instructions_layout->addWidget(capture_button);
+
+      calibrate_button = new QPushButton(tr("Calibrate"));
+      connect(calibrate_button, SIGNAL(clicked()), this, SLOT(calibrateClicked()));
+      calibration_instructions_layout->addWidget(calibrate_button);
+
+      calibration_instructions_layout->addWidget(
+          new QLabel(tr("Images where a chessboard was detected "
+                        "are saved in 'test-data/intrinsic_calibration'.\n"
+                        "You can load all images again to redo or tune "
+                        "the calibration.")));
+
+      load_images_button = new QPushButton(tr("Load saved images"));
+      connect(load_images_button, SIGNAL(clicked()), this, SLOT(loadImagesClicked()));
+      calibration_instructions_layout->addWidget(load_images_button);
+
+      reset_model_button = new QPushButton(tr("Reset model"));
+      connect(reset_model_button, SIGNAL(clicked()), this, SLOT(resetModelClicked()));
+      calibration_instructions_layout->addWidget(reset_model_button);
+    }
+
+    // images loaded
+    {
+      auto hbox = new QHBoxLayout;
+      hbox->addWidget(new QLabel(tr("Images loaded: ")));
+
+      images_loaded_label = new QLabel(tr("0 / 0"));
+      hbox->addWidget(images_loaded_label);
+
+      calibration_instructions_layout->addLayout(hbox);
+    }
+
+    auto calibration_instructions_groupbox = new QGroupBox(tr("Calibration Instructions"));
+    calibration_instructions_groupbox->setLayout(calibration_instructions_layout);
+
+    calibration_steps_layout->addWidget(calibration_instructions_groupbox);
+  }
+
+  // capture control buttons
+  {
+    auto capture_control_layout = new QVBoxLayout;
+    auto capture_control_groupbox = new QGroupBox(tr("Calibration Data"));
+    capture_control_groupbox->setLayout(capture_control_layout);
+
+    // captured data info
+    {
+      auto hbox = new QHBoxLayout;
+      hbox->addWidget(new QLabel(tr("Number of data points: ")));
+
+      num_data_points_label = new QLabel(tr("0"));
+      hbox->addWidget(num_data_points_label);
+
+      capture_control_layout->addLayout(hbox);
+    }
+
+    // calibration RMS error
+    {
+      auto hbox = new QHBoxLayout;
+      hbox->addWidget(new QLabel(tr("Calibration RMS: ")));
+
+      rms_label = new QLabel(tr("-"));
+      hbox->addWidget(rms_label);
+
+      capture_control_layout->addLayout(hbox);
+    }
+
+    capture_control_layout->addWidget(
+        new QLabel(tr("The calibration result can be found under \n"
+                      "Camera Calibrator -> Camera Parameters -> Intrinsic Parameters")));
+
+    capture_control_layout->addSpacing(50);
+
+    // control buttons
+    {
+      clear_data_button = new QPushButton(tr("Clear Data"));
+      connect(clear_data_button, SIGNAL(clicked()), this, SLOT(clearDataClicked()));
+
+      auto hbox = new QHBoxLayout;
+      hbox->addWidget(clear_data_button);
+
+      capture_control_layout->addLayout(hbox);
+    }
+
+    calibration_steps_layout->addWidget(capture_control_groupbox);
+  }
+
+  // push widgets to top
+  calibration_steps_layout->addStretch();
+
+  this->setLayout(calibration_steps_layout);
+}
+
+void CameraIntrinsicCalibrationWidget::setNumDataPoints(int n) { num_data_points_label->setText(QString("%1").arg(n)); }
+
+void CameraIntrinsicCalibrationWidget::clearDataClicked() {
+  setImagesLoaded(0, 0);
+  should_clear_data = true;
+}
+
+void CameraIntrinsicCalibrationWidget::calibrateClicked() {
+  should_calibrate = true;
+  updateConfigurationEnabled();
+}
+
+void CameraIntrinsicCalibrationWidget::updateConfigurationEnabled() {
+  pattern_selector->setEnabled(isConfigurationEnabled());
+  grid_width->setEnabled(isConfigurationEnabled());
+  grid_height->setEnabled(isConfigurationEnabled());
+  clear_data_button->setEnabled(isConfigurationEnabled());
+  detect_pattern_checkbox->setEnabled(isConfigurationEnabled());
+  corner_subpixel_correction_checkbox->setEnabled(isConfigurationEnabled());
+  load_images_button->setEnabled(isConfigurationEnabled());
+  calibrate_button->setEnabled(isConfigurationEnabled());
+  reset_model_button->setEnabled(isConfigurationEnabled());
+}
+
+void CameraIntrinsicCalibrationWidget::loadImagesClicked() {
+  setImagesLoaded(0, 0);
+  should_load_images = true;
+  updateConfigurationEnabled();
+}
+
+void CameraIntrinsicCalibrationWidget::resetModelClicked() const { camera_params.intrinsic_parameters->reset(); }
+
+void CameraIntrinsicCalibrationWidget::setRms(double rms) { rms_label->setText(QString("%1").arg(rms)); }
+
+void CameraIntrinsicCalibrationWidget::grid_height_changed(int height) const {
+  camera_params.additional_calibration_information->grid_height->setInt(height);
+}
+
+void CameraIntrinsicCalibrationWidget::grid_height_vartype_changed(VarType* varType) {
+  grid_height->setValue(((VarInt*)varType)->getInt());
+}
+
+void CameraIntrinsicCalibrationWidget::grid_width_changed(int width) const {
+  camera_params.additional_calibration_information->grid_width->setInt(width);
+}
+
+void CameraIntrinsicCalibrationWidget::grid_width_vartype_changed(VarType* varType) {
+  grid_width->setValue(((VarInt*)varType)->getInt());
+}
+
+void CameraIntrinsicCalibrationWidget::setImagesLoaded(int n, int total) {
+  images_loaded_label->setText(QString("%1 / %2").arg(n).arg(total));
+}
+
+void CameraIntrinsicCalibrationWidget::imagesLoaded() { updateConfigurationEnabled(); }

--- a/src/app/gui/camera_intrinsic_calib_widget.h
+++ b/src/app/gui/camera_intrinsic_calib_widget.h
@@ -1,0 +1,71 @@
+#ifndef CAMERA_INTRINSIC_CALIB_WIDGET_H
+#define CAMERA_INTRINSIC_CALIB_WIDGET_H
+
+#include <camera_calibration.h>
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QLabel>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QWidget>
+
+class CameraIntrinsicCalibrationWidget : public QWidget {
+  Q_OBJECT
+ public:
+  enum class Pattern : int { CHECKERBOARD = 0, CIRCLES, ASYMMETRIC_CIRCLES };
+
+ public:
+  explicit CameraIntrinsicCalibrationWidget(CameraParameters &camera_params);
+  ~CameraIntrinsicCalibrationWidget() override = default;
+
+  CameraParameters &camera_params;
+
+ protected:
+  QComboBox *pattern_selector;
+  QSpinBox *grid_width;
+  QSpinBox *grid_height;
+  QCheckBox *detect_pattern_checkbox;
+  QCheckBox *corner_subpixel_correction_checkbox;
+  QLabel *num_data_points_label;
+  QLabel *rms_label;
+  QLabel *images_loaded_label;
+  QPushButton *clear_data_button;
+  QPushButton *capture_button;
+  QPushButton *calibrate_button;
+  QPushButton *load_images_button;
+  QPushButton *reset_model_button;
+
+ public:
+  bool patternDetectionEnabled() const { return detect_pattern_checkbox->isChecked(); }
+  bool cornerSubPixCorrectionEnabled() const { return corner_subpixel_correction_checkbox->isChecked(); }
+  bool isCapturing() const { return capture_button->isChecked(); }
+  bool isLoadingFiles() const { return should_load_images; }
+  bool isConfigurationEnabled() const { return !isCapturing() && !isLoadingFiles() && !calibrating; }
+  void setNumDataPoints(int n);
+  Pattern getPattern() const { return static_cast<Pattern>(pattern_selector->currentIndex()); }
+  void setImagesLoaded(int n, int total);
+  void imagesLoaded();
+
+ public slots:
+  void clearDataClicked();
+  void calibrateClicked();
+  void updateConfigurationEnabled();
+  void loadImagesClicked();
+  void grid_height_changed(int) const;
+  void grid_height_vartype_changed(VarType* varType);
+  void grid_width_changed(int) const;
+  void grid_width_vartype_changed(VarType* varType);
+  void resetModelClicked() const;
+
+ public:
+  void setRms(double rms);
+
+ public:
+  bool should_clear_data = false;
+  bool should_load_images = false;
+  bool should_calibrate = false;
+  bool calibrating = false;
+};
+
+#endif /* CAMERA_INTRINSIC_CALIB_WIDGET_H */

--- a/src/app/gui/cameracalibwidget.cpp
+++ b/src/app/gui/cameracalibwidget.cpp
@@ -34,21 +34,39 @@ CameraCalibrationWidget::CameraCalibrationWidget(CameraParameters &_cp) : camera
   // The calibration points and the fit button:
   QGroupBox* calibrationStepsBox = new QGroupBox(tr("Calibration Steps"));
 
-  QLabel* globalCameraIdLabel = new QLabel("Global camera id ");
-  globalCameraId = new QLineEdit(QString::number(camera_parameters.additional_calibration_information->camera_index->getInt()));
+  auto globalCameraIdLabel = new QLabel("Update control points based on the "
+                                        "<a "
+                                        "href=\"https://github.com/RoboCup-SSL/"
+                                        "ssl-vision/wiki/camera-calibration\">"
+                                        "global camera id</a>: ");
+  globalCameraIdLabel->setTextFormat(Qt::RichText);
+  globalCameraIdLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
+  globalCameraIdLabel->setOpenExternalLinks(true);
+
+  globalCameraId = new QLineEdit(QString::number(camera_parameters.additional_calibration_information->global_camera_id->getInt()));
   globalCameraId->setValidator(new QIntValidator(0, 7, this));
   globalCameraId->setMaximumWidth(30);
+  connect(globalCameraId, SIGNAL(textChanged(QString)),
+      this, SLOT(global_camera_id_changed()));
+  connect(camera_parameters.additional_calibration_information->global_camera_id, SIGNAL(hasChanged(VarType*)),
+      this, SLOT(global_camera_id_vartype_changed()));
+
+  openCvCalibrationCheckBox = new QCheckBox("Use OpenCV calibration separate intrinsic and extrinsic model");
+  openCvCalibrationCheckBox->setChecked(camera_parameters.use_opencv_model->getBool());
+  connect(openCvCalibrationCheckBox, SIGNAL(stateChanged(int)), this, SLOT(opencvCalibrationTypeChanged(int)));
+  connect(camera_parameters.use_opencv_model, SIGNAL(hasChanged(VarType *)), this, SLOT(opencvCalibrationTypeChangedVarType()));
+
   QPushButton* updateControlPointsButton = new QPushButton(tr("Update control points"));
   connect(updateControlPointsButton, SIGNAL(clicked()), SLOT(is_clicked_update_control_points()));
   QPushButton* initialCalibrationButton = new QPushButton(tr("Do initial calibration"));
   connect(initialCalibrationButton, SIGNAL(clicked()), SLOT(is_clicked_initial()));
-  QPushButton* fullCalibrationButton = new QPushButton(tr("Do full calibration"));
+  fullCalibrationButton = new QPushButton(tr("Do full calibration"));
   connect(fullCalibrationButton, SIGNAL(clicked()), SLOT(is_clicked_full()));
   QPushButton* additionalPointsButton = new QPushButton(tr("Detect additional calibration points"));
   connect(additionalPointsButton, SIGNAL(clicked()), SLOT(edges_is_clicked()));
   QPushButton* resetButton = new QPushButton(tr("Reset"));
   connect(resetButton, SIGNAL(clicked()), SLOT(is_clicked_reset()));
-  
+
   QGroupBox* calibrationParametersBox = new QGroupBox(tr("Calibration Parameters"));
   // The slider for the width of the line search corridor:
   QLabel* widthLabel = new QLabel("Line Search Corridor Width (in mm) ");
@@ -59,7 +77,7 @@ CameraCalibrationWidget::CameraCalibrationWidget(CameraParameters &_cp) : camera
   lineSearchCorridorWidthLabelRight = new QLabel();
   lineSearchCorridorWidthLabelRight->setNum(200);
   connect(lineSearchCorridorWidthSlider, SIGNAL(valueChanged(int)), this, SLOT(line_search_slider_changed(int)));
-  
+
   QGroupBox* cameraParametersBox = new QGroupBox(tr("Initial Camera Parameters"));
   // The slider for height control:
   QLabel* heightLabel = new QLabel("Camera Height (in mm) ");
@@ -79,17 +97,17 @@ CameraCalibrationWidget::CameraCalibrationWidget(CameraParameters &_cp) : camera
   distortionLabelRight = new QLabel();
   distortionLabelRight->setNum(1./100. * (double)(distortionSlider->value()));
   connect(distortionSlider, SIGNAL(valueChanged(int)), this, SLOT(distortion_slider_changed(int)));
-  
+
   // Layout for calibration control:
   QHBoxLayout *hbox = new QHBoxLayout;
   hbox->addWidget(globalCameraIdLabel);
   hbox->addWidget(globalCameraId);
   hbox->addWidget(updateControlPointsButton);
-  QGroupBox* globalCameraSelectBox = new QGroupBox();
-  globalCameraSelectBox->setLayout(hbox);
+  hbox->addStretch(1);
 
   QVBoxLayout *vbox = new QVBoxLayout;
-  vbox->addWidget(globalCameraSelectBox);
+  vbox->addLayout(hbox);
+  vbox->addWidget(openCvCalibrationCheckBox);
   vbox->addWidget(initialCalibrationButton);
   vbox->addWidget(additionalPointsButton);
   vbox->addWidget(fullCalibrationButton);
@@ -111,7 +129,7 @@ CameraCalibrationWidget::CameraCalibrationWidget(CameraParameters &_cp) : camera
   gridCamera->addWidget(distortionSlider,1,1);
   gridCamera->addWidget(distortionLabelRight,1,2);
   cameraParametersBox->setLayout(gridCamera);
-  
+
   // Overall layout:
   QVBoxLayout *vbox2 = new QVBoxLayout;
   vbox2->addWidget(calibrationStepsBox);
@@ -152,7 +170,11 @@ void CameraCalibrationWidget::is_clicked_full()
 
 void CameraCalibrationWidget::is_clicked_reset()
 {
-  camera_parameters.reset();
+  if(camera_parameters.use_opencv_model->getBool()) {
+    camera_parameters.extrinsic_parameters->reset();
+  } else {
+    camera_parameters.reset();
+  }
   set_slider_from_vars();
 }
 
@@ -163,8 +185,11 @@ void CameraCalibrationWidget::edges_is_clicked()
 
 void CameraCalibrationWidget::set_slider_from_vars()
 {
-  cameraHeightSlider->setValue((int)camera_parameters.tz->getDouble());
-  distortionSlider->setValue((int)(camera_parameters.distortion->getDouble()*100));
+  if(!camera_parameters.use_opencv_model->getBool()) {
+    cameraHeightSlider->setValue((int)camera_parameters.tz->getDouble());
+    distortionSlider->setValue(
+        (int)(camera_parameters.distortion->getDouble() * 100));
+  }
   lineSearchCorridorWidthSlider->setValue((int)(camera_parameters.additional_calibration_information->line_search_corridor_width->getDouble()));
 }
 
@@ -185,4 +210,28 @@ void CameraCalibrationWidget::line_search_slider_changed(int val)
 {
   camera_parameters.additional_calibration_information->line_search_corridor_width->setDouble(val);
   lineSearchCorridorWidthLabelRight->setNum(val);
+}
+
+void CameraCalibrationWidget::global_camera_id_changed() {
+  camera_parameters.additional_calibration_information->global_camera_id->setInt(globalCameraId->text().toInt());
+}
+
+void CameraCalibrationWidget::global_camera_id_vartype_changed() {
+  globalCameraId->setText(QString::number(camera_parameters.additional_calibration_information->global_camera_id->getInt()));
+}
+
+void CameraCalibrationWidget::opencvCalibrationTypeChanged(int state) {
+  camera_parameters.use_opencv_model->setBool(state == Qt::Checked);
+  setEnabledBasedOnModel();
+}
+
+void CameraCalibrationWidget::opencvCalibrationTypeChangedVarType() {
+  openCvCalibrationCheckBox->setChecked(camera_parameters.use_opencv_model->getBool());
+  setEnabledBasedOnModel();
+}
+
+void CameraCalibrationWidget::setEnabledBasedOnModel() {
+  bool opencv_model = camera_parameters.use_opencv_model->getBool();
+  cameraHeightSlider->setEnabled(!opencv_model);
+  distortionSlider->setEnabled(!opencv_model);
 }

--- a/src/app/gui/cameracalibwidget.cpp
+++ b/src/app/gui/cameracalibwidget.cpp
@@ -51,7 +51,7 @@ CameraCalibrationWidget::CameraCalibrationWidget(CameraParameters &_cp) : camera
   connect(camera_parameters.additional_calibration_information->global_camera_id, SIGNAL(hasChanged(VarType*)),
       this, SLOT(global_camera_id_vartype_changed()));
 
-  openCvCalibrationCheckBox = new QCheckBox("Use OpenCV calibration separate intrinsic and extrinsic model");
+  openCvCalibrationCheckBox = new QCheckBox("Use OpenCV calibration with separate intrinsic and extrinsic model");
   openCvCalibrationCheckBox->setChecked(camera_parameters.use_opencv_model->getBool());
   connect(openCvCalibrationCheckBox, SIGNAL(stateChanged(int)), this, SLOT(opencvCalibrationTypeChanged(int)));
   connect(camera_parameters.use_opencv_model, SIGNAL(hasChanged(VarType *)), this, SLOT(opencvCalibrationTypeChangedVarType()));
@@ -66,6 +66,9 @@ CameraCalibrationWidget::CameraCalibrationWidget(CameraParameters &_cp) : camera
   connect(additionalPointsButton, SIGNAL(clicked()), SLOT(edges_is_clicked()));
   QPushButton* resetButton = new QPushButton(tr("Reset"));
   connect(resetButton, SIGNAL(clicked()), SLOT(is_clicked_reset()));
+
+  auto errorDescriptionLabel = new QLabel("Root Mean Squared Error (RMSE): ");
+  errorValueLabel = new QLabel("");
 
   QGroupBox* calibrationParametersBox = new QGroupBox(tr("Calibration Parameters"));
   // The slider for the width of the line search corridor:
@@ -105,6 +108,11 @@ CameraCalibrationWidget::CameraCalibrationWidget(CameraParameters &_cp) : camera
   hbox->addWidget(updateControlPointsButton);
   hbox->addStretch(1);
 
+  auto errorLayout = new QHBoxLayout;
+  errorLayout->addWidget(errorDescriptionLabel);
+  errorLayout->addWidget(errorValueLabel);
+  errorLayout->addStretch(1);
+
   QVBoxLayout *vbox = new QVBoxLayout;
   vbox->addLayout(hbox);
   vbox->addWidget(openCvCalibrationCheckBox);
@@ -112,6 +120,7 @@ CameraCalibrationWidget::CameraCalibrationWidget(CameraParameters &_cp) : camera
   vbox->addWidget(additionalPointsButton);
   vbox->addWidget(fullCalibrationButton);
   vbox->addWidget(resetButton);
+  vbox->addLayout(errorLayout);
   vbox->addStretch(1);
   calibrationStepsBox->setLayout(vbox);
   // Layout for calibration parameters
@@ -158,13 +167,15 @@ void CameraCalibrationWidget::is_clicked_update_control_points()
 
 void CameraCalibrationWidget::is_clicked_initial()
 {
-  camera_parameters.do_calibration(CameraParameters::FOUR_POINT_INITIAL);
+  double rmse = camera_parameters.do_calibration(CameraParameters::FOUR_POINT_INITIAL);
+  errorValueLabel->setText(QString::number(rmse));
   set_slider_from_vars();
 }
 
 void CameraCalibrationWidget::is_clicked_full()
 {
-  camera_parameters.do_calibration(CameraParameters::FULL_ESTIMATION);
+  double rmse = camera_parameters.do_calibration(CameraParameters::FULL_ESTIMATION);
+  errorValueLabel->setText(QString::number(rmse));
   set_slider_from_vars();
 }
 

--- a/src/app/gui/cameracalibwidget.cpp
+++ b/src/app/gui/cameracalibwidget.cpp
@@ -181,6 +181,7 @@ void CameraCalibrationWidget::is_clicked_full()
 
 void CameraCalibrationWidget::is_clicked_reset()
 {
+  camera_parameters.calibrationSegments.clear();
   if(camera_parameters.use_opencv_model->getBool()) {
     camera_parameters.extrinsic_parameters->reset();
   } else {

--- a/src/app/gui/cameracalibwidget.h
+++ b/src/app/gui/cameracalibwidget.h
@@ -37,16 +37,18 @@ public:
     void focusInEvent ( QFocusEvent * event );
     CameraCalibrationWidget(CameraParameters &cp);
     ~CameraCalibrationWidget();
-    
+
     CameraParameters& camera_parameters;
-    
+
     bool getDetectEdges() {return detectEdges;}
-    
+
     void resetDetectEdges() {detectEdges = false;}
-    
-    void set_slider_from_vars();    
-    
+
+    void set_slider_from_vars();
+
   protected:
+    QPushButton* fullCalibrationButton;
+
     QSlider* lineSearchCorridorWidthSlider;
     QLabel* lineSearchCorridorWidthLabelRight;
     QSlider* cameraHeightSlider;
@@ -54,6 +56,7 @@ public:
     QSlider* distortionSlider;
     QLabel* distortionLabelRight;
     QLineEdit* globalCameraId;
+    QCheckBox* openCvCalibrationCheckBox;
     bool detectEdges;
 
     public slots:
@@ -65,6 +68,13 @@ public:
     void cameraheight_slider_changed(int val);
     void distortion_slider_changed(int val);
     void line_search_slider_changed(int val);
+    void global_camera_id_changed();
+    void global_camera_id_vartype_changed();
+    void opencvCalibrationTypeChanged(int val);
+    void opencvCalibrationTypeChangedVarType();
+
+private:
+  void setEnabledBasedOnModel();
 };
 
 #endif

--- a/src/app/gui/cameracalibwidget.h
+++ b/src/app/gui/cameracalibwidget.h
@@ -48,6 +48,7 @@ public:
 
   protected:
     QPushButton* fullCalibrationButton;
+    QLabel* errorValueLabel;
 
     QSlider* lineSearchCorridorWidthSlider;
     QLabel* lineSearchCorridorWidthLabelRight;

--- a/src/app/plugins/plugin_camera_intrinsic_calib.cpp
+++ b/src/app/plugins/plugin_camera_intrinsic_calib.cpp
@@ -1,0 +1,360 @@
+#include "plugin_camera_intrinsic_calib.h"
+
+#include <dirent.h>
+
+#include <chrono>
+#include <iostream>
+
+#include "conversions_greyscale.h"
+
+PluginCameraIntrinsicCalibration::PluginCameraIntrinsicCalibration(FrameBuffer *buffer,
+                                                                   CameraParameters &_camera_params)
+    : VisionPlugin(buffer),
+      settings(new VarList("Camera Intrinsic Calibration")),
+      widget(new CameraIntrinsicCalibrationWidget(_camera_params)),
+      camera_params(_camera_params) {
+  worker = new PluginCameraIntrinsicCalibrationWorker(_camera_params, widget);
+
+  chessboard_capture_dt = new VarDouble("chessboard capture dT", 0.2);
+
+  auto corner_sub_pixel_list = new VarList("corner sub pixel detection");
+  corner_sub_pixel_list->addChild(worker->corner_sub_pixel_windows_size);
+  corner_sub_pixel_list->addChild(worker->corner_sub_pixel_max_iterations);
+  corner_sub_pixel_list->addChild(worker->corner_sub_pixel_epsilon);
+
+  settings->addChild(worker->image_storage->image_dir);
+  settings->addChild(worker->reduced_image_width);
+  settings->addChild(chessboard_capture_dt);
+  settings->addChild(worker->corner_diff_sq_threshold);
+  settings->addChild(corner_sub_pixel_list);
+  settings->addChild(worker->fixFocalLength);
+  settings->addChild(worker->fixPrinciplePoint);
+  settings->addChild(worker->initializeCameraMatrix);
+
+  connect(this, SIGNAL(startLoadImages()), worker, SLOT(loadImages()));
+  connect(this, SIGNAL(startCalibration()), worker, SLOT(calibrate()));
+  connect(this, SIGNAL(startSaveImages()), worker->image_storage, SLOT(saveImages()));
+}
+
+PluginCameraIntrinsicCalibration::~PluginCameraIntrinsicCalibration() {
+  worker->deleteLater();
+  delete widget;
+  delete worker;
+  delete chessboard_capture_dt;
+}
+
+VarList *PluginCameraIntrinsicCalibration::getSettings() { return settings.get(); }
+
+std::string PluginCameraIntrinsicCalibration::getName() { return "Camera Intrinsic Calibration"; }
+
+QWidget *PluginCameraIntrinsicCalibration::getControlWidget() { return static_cast<QWidget *>(worker->widget); }
+
+ProcessResult PluginCameraIntrinsicCalibration::process(FrameData *data, RenderOptions *options) {
+  (void)options;
+
+  Image<raw8> *img_calibration;
+  if ((img_calibration = reinterpret_cast<Image<raw8> *>(data->map.get("img_calibration"))) == nullptr) {
+    img_calibration = reinterpret_cast<Image<raw8> *>(data->map.insert("img_calibration", new Image<raw8>()));
+  }
+
+  ConversionsGreyscale::cvColor2Grey(data->video, img_calibration);
+
+  Chessboard *chessboard;
+  if ((chessboard = reinterpret_cast<Chessboard *>(data->map.get("chessboard"))) == nullptr) {
+    chessboard = reinterpret_cast<Chessboard *>(data->map.insert("chessboard", new Chessboard()));
+  }
+
+  // cv expects row major order and image stores col major.
+  // height and width are swapped intentionally!
+  cv::Mat greyscale_mat(img_calibration->getHeight(), img_calibration->getWidth(), CV_8UC1, img_calibration->getData());
+  worker->imageSize = greyscale_mat.size();
+
+  if (widget->should_load_images) {
+    widget->should_load_images = false;
+    emit startLoadImages();
+  }
+
+  if (widget->patternDetectionEnabled() || widget->isCapturing()) {
+    worker->detectChessboard(greyscale_mat, chessboard);
+  }
+
+  if (widget->isCapturing() && chessboard->pattern_was_found) {
+    double captureDiff = data->video.getTime() - lastChessboardCaptureFrame;
+    if (captureDiff < chessboard_capture_dt->getDouble()) {
+      return ProcessingOk;
+    }
+    lastChessboardCaptureFrame = data->video.getTime();
+
+    bool added = worker->addChessboard(chessboard);
+
+    if (added) {
+      worker->image_storage->image_save_mutex.lock();
+      worker->image_storage->images_to_save.push(greyscale_mat.clone());
+      worker->image_storage->image_save_mutex.unlock();
+      emit startSaveImages();
+    }
+  }
+
+  if (widget->should_calibrate) {
+    widget->should_calibrate = false;
+    emit startCalibration();
+  }
+
+  if (widget->should_clear_data) {
+    widget->should_clear_data = false;
+    worker->clearData();
+  }
+
+  return ProcessingOk;
+}
+
+PluginCameraIntrinsicCalibrationWorker::PluginCameraIntrinsicCalibrationWorker(CameraParameters &_camera_params,
+                                                                               CameraIntrinsicCalibrationWidget *widget)
+    : widget(widget), camera_params(_camera_params) {
+  corner_sub_pixel_windows_size = new VarInt("window size", 5, 1);
+  corner_sub_pixel_max_iterations = new VarInt("max iterations", 30, 1);
+  corner_sub_pixel_epsilon = new VarDouble("epsilon", 0.1, 1e-10);
+  corner_diff_sq_threshold = new VarDouble("corner sq_diff threshold", 500);
+  reduced_image_width = new VarDouble("reduced image width for chessboard detection", 900.0);
+  fixFocalLength = new VarBool("Fix focal length", true);
+  fixPrinciplePoint = new VarBool("Fix principle point", true);
+  initializeCameraMatrix = new VarBool("Initialize camera matrix", true);
+
+  image_storage = new ImageStorage(widget);
+
+  thread = new QThread();
+  thread->setObjectName("IntrinsicCalibration");
+  moveToThread(thread);
+  thread->start();
+}
+
+PluginCameraIntrinsicCalibrationWorker::~PluginCameraIntrinsicCalibrationWorker() {
+  thread->quit();
+  thread->deleteLater();
+
+  delete image_storage;
+  delete corner_sub_pixel_windows_size;
+  delete corner_sub_pixel_epsilon;
+  delete corner_sub_pixel_max_iterations;
+  delete corner_diff_sq_threshold;
+  delete reduced_image_width;
+  delete fixFocalLength;
+  delete fixPrinciplePoint;
+  delete initializeCameraMatrix;
+}
+
+void PluginCameraIntrinsicCalibrationWorker::calibrate() {
+  calib_mutex.lock();
+  widget->calibrating = true;
+  widget->updateConfigurationEnabled();
+
+  std::vector<cv::Mat> rvecs;
+  std::vector<cv::Mat> tvecs;
+
+  int flags = 0;
+  if (fixFocalLength->getBool()) {
+    flags |= cv::CALIB_FIX_FOCAL_LENGTH;
+  }
+  if (fixPrinciplePoint->getBool()) {
+    flags |= cv::CALIB_FIX_PRINCIPAL_POINT;
+  }
+  if (!initializeCameraMatrix->getBool()) {
+    flags |= cv::CALIB_USE_INTRINSIC_GUESS;
+  }
+
+  try {
+    std::cout << "Start calibrating with " << image_points.size() << " samples" << std::endl;
+    auto start = std::chrono::high_resolution_clock::now();
+
+    double rms =
+        cv::calibrateCamera(object_points, image_points, imageSize, camera_params.intrinsic_parameters->camera_mat,
+                            camera_params.intrinsic_parameters->dist_coeffs, rvecs, tvecs, flags);
+
+    auto finish = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = finish - start;
+    std::cout << "Calibration finished with RMS=" << rms << " in " << elapsed.count() << "s" << std::endl;
+    camera_params.intrinsic_parameters->updateConfigValues();
+    this->widget->setRms(rms);
+  } catch (cv::Exception &e) {
+    std::cerr << "calibration failed: " << e.err << std::endl;
+    this->widget->setRms(-1);
+  }
+
+  widget->calibrating = false;
+  widget->updateConfigurationEnabled();
+  calib_mutex.unlock();
+}
+
+bool PluginCameraIntrinsicCalibrationWorker::addChessboard(const Chessboard *chessboard) {
+  calib_mutex.lock();
+
+  // Check if there is a similar sample already
+  for (const auto &img_points : this->image_points) {
+    double sq_diff_sum = 0;
+    for (uint i = 0; i < img_points.size(); i++) {
+      double diff = cv::norm(img_points[i] - chessboard->corners[i]);
+      sq_diff_sum += diff * diff;
+    }
+    double sq_diff = sq_diff_sum / (double)img_points.size();
+    if (sq_diff < this->corner_diff_sq_threshold->getDouble()) {
+      calib_mutex.unlock();
+      return false;
+    }
+  }
+
+  this->image_points.push_back(chessboard->corners);
+
+  std::vector<cv::Point3f> obj;
+  for (int y = 0; y < chessboard->pattern_size.height; y++) {
+    for (int x = 0; x < chessboard->pattern_size.width; x++) {
+      obj.emplace_back(x, y, 0.0f);
+    }
+  }
+  this->object_points.push_back(obj);
+
+  this->widget->setNumDataPoints((int)this->object_points.size());
+  calib_mutex.unlock();
+  return true;
+}
+
+void PluginCameraIntrinsicCalibrationWorker::detectChessboard(const cv::Mat &greyscale_mat,
+                                                              Chessboard *chessboard) const {
+  chessboard->pattern_size.height = this->camera_params.additional_calibration_information->grid_height->getInt();
+  chessboard->pattern_size.width = this->camera_params.additional_calibration_information->grid_width->getInt();
+  chessboard->corners.clear();
+
+  cv::Mat greyscale_mat_low_res;
+  double scale_factor = min(1.0, reduced_image_width->getDouble() / greyscale_mat.size().width);
+  cv::resize(greyscale_mat, greyscale_mat_low_res, cv::Size(), scale_factor, scale_factor);
+
+  std::vector<cv::Point2f> corners_low_res;
+  chessboard->pattern_was_found = this->findPattern(greyscale_mat_low_res, chessboard->pattern_size, corners_low_res);
+
+  for (auto &corner : corners_low_res) {
+    double x = corner.x / scale_factor;
+    double y = corner.y / scale_factor;
+    chessboard->corners.push_back(cv::Point((int) x, (int) y));
+  }
+
+  if (chessboard->pattern_was_found && this->widget->cornerSubPixCorrectionEnabled()) {
+    cv::cornerSubPix(
+        greyscale_mat, chessboard->corners,
+        cv::Size(corner_sub_pixel_windows_size->getInt(), corner_sub_pixel_windows_size->getInt()), cv::Size(-1, -1),
+        cv::TermCriteria(cv::TermCriteria::EPS | cv::TermCriteria::MAX_ITER, corner_sub_pixel_max_iterations->getInt(),
+                         corner_sub_pixel_epsilon->getDouble()));
+  }
+}
+
+bool PluginCameraIntrinsicCalibrationWorker::findPattern(const cv::Mat &image, const cv::Size &pattern_size,
+                                                         vector<cv::Point2f> &corners) const {
+  using Pattern = CameraIntrinsicCalibrationWidget::Pattern;
+  int cb_flags = cv::CALIB_CB_ADAPTIVE_THRESH + cv::CALIB_CB_FAST_CHECK + cv::CALIB_CB_NORMALIZE_IMAGE;
+
+  switch (widget->getPattern()) {
+    case Pattern::CHECKERBOARD:
+      return cv::findChessboardCorners(image, pattern_size, corners, cb_flags);
+    case Pattern::CIRCLES:
+      return cv::findCirclesGrid(image, pattern_size, corners);
+    case Pattern::ASYMMETRIC_CIRCLES:
+      return cv::findCirclesGrid(image, pattern_size, corners, cv::CALIB_CB_ASYMMETRIC_GRID);
+    default:
+      return false;
+  }
+}
+
+void PluginCameraIntrinsicCalibrationWorker::loadImages() {
+  std::vector<cv::Mat> images;
+  image_storage->readImages(images);
+
+  int n = 0;
+  for (cv::Mat &mat : images) {
+    Chessboard image_chessboard;
+    detectChessboard(mat, &image_chessboard);
+    if (image_chessboard.pattern_was_found) {
+      bool added = addChessboard(&image_chessboard);
+      if (added) {
+        std::cout << "Added chessboard" << std::endl;
+      } else {
+        std::cout << "Filtered chessboard" << std::endl;
+      }
+    } else {
+      std::cout << "No chessboard detected" << std::endl;
+    }
+    n++;
+    widget->setImagesLoaded(n, (int) images.size());
+  }
+  calibrate();
+  widget->imagesLoaded();
+}
+
+void PluginCameraIntrinsicCalibrationWorker::clearData() {
+  calib_mutex.lock();
+
+  image_points.clear();
+  object_points.clear();
+
+  widget->setNumDataPoints((int) object_points.size());
+  widget->setRms(0.0);
+
+  calib_mutex.unlock();
+}
+
+ImageStorage::ImageStorage(CameraIntrinsicCalibrationWidget *widget) : widget(widget) {
+  image_dir = new VarString("pattern image dir", "test-data/intrinsic_calibration");
+
+  thread = new QThread();
+  thread->setObjectName("IntrinsicCalibrationImageStorage");
+  moveToThread(thread);
+  thread->start();
+}
+
+ImageStorage::~ImageStorage() {
+  thread->quit();
+  thread->deleteLater();
+  delete image_dir;
+}
+
+void ImageStorage::saveImages() {
+  image_save_mutex.lock();
+  if (images_to_save.empty()) {
+    image_save_mutex.unlock();
+  } else {
+    cv::Mat image = images_to_save.front();
+    images_to_save.pop();
+    image_save_mutex.unlock();
+    saveImage(image);
+    saveImages();
+  }
+}
+
+void ImageStorage::saveImage(cv::Mat &image) const {
+  long t_now = (long)(GetTimeSec() * 1e9);
+  QString num = QString::number(t_now);
+  QString filename = QString(image_dir->getString().c_str()) + "/" + num + ".png";
+  cv::imwrite(filename.toStdString(), image);
+}
+
+void ImageStorage::readImages(std::vector<cv::Mat> &images) const {
+  DIR *dp;
+  if ((dp = opendir(image_dir->getString().c_str())) == nullptr) {
+    std::cerr << "Failed to open directory: " << image_dir->getString() << std::endl;
+    return;
+  }
+  struct dirent *dirp;
+  std::list<std::string> imgs_to_load(0);
+  while ((dirp = readdir(dp))) {
+    std::string file_name(dirp->d_name);
+    if (file_name[0] != '.') {  // not a hidden file or one of '..' or '.'
+      imgs_to_load.push_back(image_dir->getString() + "/" + file_name);
+    }
+  }
+  closedir(dp);
+
+  imgs_to_load.sort();
+  for (const auto &currentImage : imgs_to_load) {
+    std::cout << "Loading " << currentImage << std::endl;
+    cv::Mat srcImg = imread(currentImage, cv::IMREAD_GRAYSCALE);
+    images.push_back(srcImg);
+    widget->setImagesLoaded(0, (int) images.size());
+  }
+}

--- a/src/app/plugins/plugin_camera_intrinsic_calib.cpp
+++ b/src/app/plugins/plugin_camera_intrinsic_calib.cpp
@@ -29,7 +29,11 @@ PluginCameraIntrinsicCalibration::PluginCameraIntrinsicCalibration(FrameBuffer *
   settings->addChild(corner_sub_pixel_list);
   settings->addChild(worker->fixFocalLength);
   settings->addChild(worker->fixPrinciplePoint);
-  settings->addChild(worker->initializeCameraMatrix);
+  settings->addChild(worker->fixTangentialDistortion);
+  settings->addChild(worker->fixK1);
+  settings->addChild(worker->fixK2);
+  settings->addChild(worker->fixK3);
+  settings->addChild(worker->useIntrinsicGuess);
 
   connect(this, SIGNAL(startLoadImages()), worker, SLOT(loadImages()));
   connect(this, SIGNAL(startCalibration()), worker, SLOT(calibrate()));
@@ -118,7 +122,11 @@ PluginCameraIntrinsicCalibrationWorker::PluginCameraIntrinsicCalibrationWorker(C
   reduced_image_width = new VarDouble("reduced image width for chessboard detection", 900.0);
   fixFocalLength = new VarBool("Fix focal length", true);
   fixPrinciplePoint = new VarBool("Fix principle point", true);
-  initializeCameraMatrix = new VarBool("Initialize camera matrix", true);
+  fixTangentialDistortion = new VarBool("Fix tangential distortion", false);
+  fixK1 = new VarBool("Fix k1", false);
+  fixK2 = new VarBool("Fix k2", false);
+  fixK3 = new VarBool("Fix k3", false);
+  useIntrinsicGuess = new VarBool("Use intrinsic guess", true);
 
   image_storage = new ImageStorage(widget);
 
@@ -140,7 +148,11 @@ PluginCameraIntrinsicCalibrationWorker::~PluginCameraIntrinsicCalibrationWorker(
   delete reduced_image_width;
   delete fixFocalLength;
   delete fixPrinciplePoint;
-  delete initializeCameraMatrix;
+  delete fixTangentialDistortion;
+  delete fixK1;
+  delete fixK2;
+  delete fixK3;
+  delete useIntrinsicGuess;
 }
 
 void PluginCameraIntrinsicCalibrationWorker::calibrate() {
@@ -158,7 +170,19 @@ void PluginCameraIntrinsicCalibrationWorker::calibrate() {
   if (fixPrinciplePoint->getBool()) {
     flags |= cv::CALIB_FIX_PRINCIPAL_POINT;
   }
-  if (!initializeCameraMatrix->getBool()) {
+  if (fixTangentialDistortion->getBool()) {
+    flags |=cv::CALIB_FIX_TANGENT_DIST;
+  }
+  if (fixK1->getBool()) {
+    flags |=cv::CALIB_FIX_K1;
+  }
+  if (fixK2->getBool()) {
+    flags |=cv::CALIB_FIX_K2;
+  }
+  if (fixK3->getBool()) {
+    flags |=cv::CALIB_FIX_K3;
+  }
+  if (useIntrinsicGuess->getBool()) {
     flags |= cv::CALIB_USE_INTRINSIC_GUESS;
   }
 

--- a/src/app/plugins/plugin_camera_intrinsic_calib.cpp
+++ b/src/app/plugins/plugin_camera_intrinsic_calib.cpp
@@ -358,6 +358,14 @@ void ImageStorage::saveImage(cv::Mat &image) const {
   cv::imwrite(filename.toStdString(), image);
 }
 
+static bool hasEnding (std::string const &fullString, std::string const &ending) {
+  if (fullString.length() >= ending.length()) {
+    return (0 == fullString.compare (fullString.length() - ending.length(), ending.length(), ending));
+  } else {
+    return false;
+  }
+}
+
 void ImageStorage::readImages(std::vector<cv::Mat> &images) const {
   DIR *dp;
   if ((dp = opendir(image_dir->getString().c_str())) == nullptr) {
@@ -368,7 +376,7 @@ void ImageStorage::readImages(std::vector<cv::Mat> &images) const {
   std::list<std::string> imgs_to_load(0);
   while ((dirp = readdir(dp))) {
     std::string file_name(dirp->d_name);
-    if (file_name[0] != '.') {  // not a hidden file or one of '..' or '.'
+    if (file_name[0] != '.' && hasEnding(file_name, ".png")) {  // not a hidden file or one of '..' or '.'
       imgs_to_load.push_back(image_dir->getString() + "/" + file_name);
     }
   }

--- a/src/app/plugins/plugin_camera_intrinsic_calib.cpp
+++ b/src/app/plugins/plugin_camera_intrinsic_calib.cpp
@@ -68,6 +68,10 @@ ProcessResult PluginCameraIntrinsicCalibration::process(FrameData *data, RenderO
     chessboard = reinterpret_cast<Chessboard *>(data->map.insert("chessboard", new Chessboard()));
   }
 
+  if (data->map.get("chessboard_img_points") == nullptr) {
+    data->map.insert("chessboard_img_points", &worker->image_points);
+  }
+
   // cv expects row major order and image stores col major.
   // height and width are swapped intentionally!
   cv::Mat greyscale_mat(img_calibration->getHeight(), img_calibration->getWidth(), CV_8UC1, img_calibration->getData());

--- a/src/app/plugins/plugin_camera_intrinsic_calib.cpp
+++ b/src/app/plugins/plugin_camera_intrinsic_calib.cpp
@@ -124,13 +124,13 @@ PluginCameraIntrinsicCalibrationWorker::PluginCameraIntrinsicCalibrationWorker(C
   corner_sub_pixel_epsilon = new VarDouble("epsilon", 0.1, 1e-10);
   corner_diff_sq_threshold = new VarDouble("corner sq_diff threshold", 500);
   reduced_image_width = new VarDouble("reduced image width for chessboard detection", 900.0);
-  fixFocalLength = new VarBool("Fix focal length", true);
-  fixPrinciplePoint = new VarBool("Fix principle point", true);
-  fixTangentialDistortion = new VarBool("Fix tangential distortion", false);
+  fixFocalLength = new VarBool("Fix focal length", false);
+  fixPrinciplePoint = new VarBool("Fix principle point", false);
+  fixTangentialDistortion = new VarBool("Fix tangential distortion", true);
   fixK1 = new VarBool("Fix k1", false);
   fixK2 = new VarBool("Fix k2", false);
   fixK3 = new VarBool("Fix k3", false);
-  useIntrinsicGuess = new VarBool("Use intrinsic guess", true);
+  useIntrinsicGuess = new VarBool("Use intrinsic guess", false);
 
   image_storage = new ImageStorage(widget);
 

--- a/src/app/plugins/plugin_camera_intrinsic_calib.h
+++ b/src/app/plugins/plugin_camera_intrinsic_calib.h
@@ -63,7 +63,11 @@ public:
   VarDouble *reduced_image_width;
   VarBool *fixFocalLength;
   VarBool *fixPrinciplePoint;
-  VarBool *initializeCameraMatrix;
+  VarBool *fixTangentialDistortion;
+  VarBool *fixK1;
+  VarBool *fixK2;
+  VarBool *fixK3;
+  VarBool *useIntrinsicGuess;
 
   void detectChessboard(const cv::Mat &greyscale_mat,
                         Chessboard *chessboard) const;

--- a/src/app/plugins/plugin_camera_intrinsic_calib.h
+++ b/src/app/plugins/plugin_camera_intrinsic_calib.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <QThread>
+#include <VarTypes.h>
+#include <camera_calibration.h>
+#include <camera_intrinsic_calib_widget.h>
+#include <camera_parameters.h>
+#include <framedata.h>
+#include <image.h>
+#include <memory>
+#include <mutex>
+#include <opencv2/opencv.hpp>
+#include <visionplugin.h>
+
+class Chessboard {
+public:
+  std::vector<cv::Point2f> corners;
+  cv::Size pattern_size;
+  bool pattern_was_found;
+};
+
+class ImageStorage : public QObject {
+  Q_OBJECT
+public:
+  explicit ImageStorage(CameraIntrinsicCalibrationWidget *widget);
+  ~ImageStorage() override;
+  QThread *thread;
+  CameraIntrinsicCalibrationWidget *widget;
+
+  std::mutex image_save_mutex;
+  std::queue<cv::Mat> images_to_save;
+
+  VarString *image_dir;
+
+  void saveImage(cv::Mat& image) const;
+  void readImages(std::vector<cv::Mat> &images) const;
+
+public slots:
+  void saveImages();
+};
+
+class PluginCameraIntrinsicCalibrationWorker : public QObject {
+  Q_OBJECT
+public:
+  PluginCameraIntrinsicCalibrationWorker(
+      CameraParameters &_camera_params,
+      CameraIntrinsicCalibrationWidget *widget);
+  ~PluginCameraIntrinsicCalibrationWorker() override;
+  QThread *thread;
+  std::mutex calib_mutex;
+
+  CameraIntrinsicCalibrationWidget *widget;
+  ImageStorage *image_storage;
+
+  std::vector<std::vector<cv::Point3f>> object_points;
+  std::vector<std::vector<cv::Point2f>> image_points;
+  cv::Size imageSize;
+
+  VarInt *corner_sub_pixel_windows_size;
+  VarInt *corner_sub_pixel_max_iterations;
+  VarDouble *corner_sub_pixel_epsilon;
+  VarDouble *corner_diff_sq_threshold;
+  VarDouble *reduced_image_width;
+  VarBool *fixFocalLength;
+  VarBool *fixPrinciplePoint;
+  VarBool *initializeCameraMatrix;
+
+  void detectChessboard(const cv::Mat &greyscale_mat,
+                        Chessboard *chessboard) const;
+  bool findPattern(const cv::Mat &image, const cv::Size &pattern_size,
+                   vector<cv::Point2f> &corners) const;
+
+  bool addChessboard(const Chessboard *chessboard);
+
+  void clearData();
+
+public slots:
+  void loadImages();
+  void calibrate();
+
+private:
+  CameraParameters camera_params;
+};
+
+class PluginCameraIntrinsicCalibration : public VisionPlugin {
+  Q_OBJECT
+protected:
+  std::unique_ptr<VarList> settings;
+
+public:
+  PluginCameraIntrinsicCalibration(FrameBuffer *_buffer,
+                                   CameraParameters &camera_params);
+  ~PluginCameraIntrinsicCalibration() override;
+
+  QWidget *getControlWidget() override;
+
+  ProcessResult process(FrameData *data, RenderOptions *options) override;
+  VarList *getSettings() override;
+  std::string getName() override;
+
+signals:
+  void startLoadImages();
+  void startCalibration();
+  void startSaveImages();
+
+private:
+  PluginCameraIntrinsicCalibrationWorker *worker;
+
+  CameraIntrinsicCalibrationWidget *widget;
+  CameraParameters camera_params;
+
+  VarDouble *chessboard_capture_dt;
+
+  double lastChessboardCaptureFrame = 0.0;
+};

--- a/src/app/plugins/plugin_cameracalib.cpp
+++ b/src/app/plugins/plugin_cameracalib.cpp
@@ -275,12 +275,6 @@ void PluginCameraCalibration::detectEdgesOnSingleArc(
   }
 }
 
-void PluginCameraCalibration::mouseEvent( QMouseEvent * event, pixelloc loc)
-{
-  (void) event;
-  (void) loc;
-}
-
 void PluginCameraCalibration::keyPressEvent ( QKeyEvent * event )
 {
   (void) event;

--- a/src/app/plugins/plugin_cameracalib.cpp
+++ b/src/app/plugins/plugin_cameracalib.cpp
@@ -204,10 +204,11 @@ void PluginCameraCalibration::detectEdgesOnSingleLine(
     Sobel::centerOfLine(
         *grey_image, start_image.x, end_image.x, start_image.y,
         end_image.y, point_image, center_found, kSobelThreshold);
-    calibration_data.imgPts.push_back(std::make_pair(point_image,center_found));
+    CameraParameters::CalibrationDataPoint point(point_image, center_found);
+    calibration_data.points.push_back(point);
     calibration_data.alphas.push_back(alpha);
   }
-  if (calibration_data.imgPts.size() > 2) {
+  if (calibration_data.points.size() > 2) {
     // Need at least two points to uniquely define a line segment.
     camera_parameters.calibrationSegments.push_back(calibration_data);
   }
@@ -271,10 +272,11 @@ void PluginCameraCalibration::detectEdgesOnSingleArc(
     Sobel::centerOfLine(
         *grey_image, start_image.x, end_image.x, start_image.y,
         end_image.y, point_image, center_found, kSobelThreshold);
-    calibration_data.imgPts.push_back(std::make_pair(point_image,center_found));
+    CameraParameters::CalibrationDataPoint point(point_image, center_found);
+    calibration_data.points.push_back(point);
     calibration_data.alphas.push_back(alpha);
   }
-  if (calibration_data.imgPts.size() > 3) {
+  if (calibration_data.points.size() > 3) {
     // Need at least three points to uniquely define a circular arc.
     camera_parameters.calibrationSegments.push_back(calibration_data);
   }

--- a/src/app/plugins/plugin_cameracalib.cpp
+++ b/src/app/plugins/plugin_cameracalib.cpp
@@ -33,8 +33,8 @@ PluginCameraCalibration::PluginCameraCalibration(
     RoboCupField& _field) :
     VisionPlugin(_buffer), camera_parameters(camera_params),
     field(_field),
-    ccw(0), grey_image(0), rgb_image(0), doing_drag(false), drag_x(0),
-    drag_y(0) {
+    ccw(nullptr), grey_image(nullptr), rgb_image(nullptr), drag_x(nullptr),
+    drag_y(nullptr), calib_drag_x(nullptr), calib_drag_y(nullptr) {
   video_width=video_height=0;
   settings=new VarList("Camera Calibrator");
   settings->addChild(camera_settings = new VarList("Camera Parameters"));
@@ -97,6 +97,11 @@ void PluginCameraCalibration::detectEdges(FrameData* data) {
     detectEdgesOnSingleArc(center, arc.radius->getDouble(), arc.a1->getDouble(),
         arc.a2->getDouble(), arc.thickness->getDouble(), point_separation);
   }
+
+  if (camera_parameters.use_opencv_model->getBool()) {
+    camera_parameters.detectCalibrationCorners();
+  }
+
   field.field_markings_mutex.unlock();
 }
 
@@ -282,14 +287,26 @@ void PluginCameraCalibration::keyPressEvent ( QKeyEvent * event )
 
 void PluginCameraCalibration::mousePressEvent ( QMouseEvent * event, pixelloc loc )
 {
-  QTabWidget* tabw = (QTabWidget*) ccw->parentWidget()->parentWidget();
+  auto tabw = (QTabWidget*) ccw->parentWidget()->parentWidget();
   double drag_threshold = 20; //in px
   if (tabw->currentWidget() == ccw && (event->buttons() & Qt::LeftButton)!=0) {
-    drag_x = 0;
-    drag_y = 0;
-    for (int i = 0;
-        i < CameraParameters::AdditionalCalibrationInformation::kNumControlPoints;
-        ++i) {
+    drag_x = nullptr;
+    drag_y = nullptr;
+    calib_drag_x = nullptr;
+    calib_drag_y = nullptr;
+    for (int i = 0; i < camera_parameters.extrinsic_parameters->getCalibrationPointSize(); i++) {
+      auto point_x = camera_parameters.extrinsic_parameters->getCalibImageValueX(i);
+      auto point_y = camera_parameters.extrinsic_parameters->getCalibImageValueY(i);
+      double x_diff = point_x->getDouble() - loc.x;
+      double y_diff = point_y->getDouble() - loc.y;
+      if (sqrt(x_diff*x_diff + y_diff*y_diff) < drag_threshold) {
+        calib_drag_x = point_x;
+        calib_drag_y = point_y;
+        event->accept();
+        return;
+      }
+    }
+    for (int i = 0; i < CameraParameters::AdditionalCalibrationInformation::kNumControlPoints; ++i) {
       const double x_diff =
           camera_parameters.additional_calibration_information->
               control_point_image_xs[i]->getDouble() - loc.x;
@@ -301,29 +318,24 @@ void PluginCameraCalibration::mousePressEvent ( QMouseEvent * event, pixelloc lo
             control_point_image_xs[i];
         drag_y = camera_parameters.additional_calibration_information->
             control_point_image_ys[i];
-        break;
+        event->accept();
+        return;
       }
     }
-    if (drag_x != 0 && drag_y != 0)
-    {
-      event->accept();
-      doing_drag = true;
-    }
-    else
-      event->ignore();
-  } else {
-    event->ignore();
   }
-
+  event->ignore();
 }
 
 void PluginCameraCalibration::mouseReleaseEvent ( QMouseEvent * event, pixelloc loc )
 {
   (void)loc;
-  QTabWidget* tabw = (QTabWidget*) ccw->parentWidget()->parentWidget();
+  auto tabw = (QTabWidget*) ccw->parentWidget()->parentWidget();
   if (tabw->currentWidget() == ccw)
   {
-    doing_drag =false;
+    drag_x = nullptr;
+    drag_y = nullptr;
+    calib_drag_x = nullptr;
+    calib_drag_y = nullptr;
     event->accept();
   }
   else
@@ -332,16 +344,22 @@ void PluginCameraCalibration::mouseReleaseEvent ( QMouseEvent * event, pixelloc 
 
 void PluginCameraCalibration::mouseMoveEvent ( QMouseEvent * event, pixelloc loc )
 {
-  QTabWidget* tabw = (QTabWidget*) ccw->parentWidget()->parentWidget();
-  if (doing_drag && tabw->currentWidget() == ccw && (event->buttons() & Qt::LeftButton)!=0)
+  auto tabw = (QTabWidget*) ccw->parentWidget()->parentWidget();
+  if (tabw->currentWidget() == ccw && (event->buttons() & Qt::LeftButton)!=0)
   {
     if (loc.x < 0) loc.x=0;
     if (loc.y < 0) loc.y=0;
     if (video_width > 0 && loc.x >= video_width) loc.x=video_width-1;
     if (video_height > 0 && loc.y >= video_height) loc.y=video_height-1;
-    drag_x->setDouble(loc.x);
-    drag_y->setDouble(loc.y);
-    event->accept();
+    if (drag_x != nullptr && drag_y != nullptr) {
+      drag_x->setDouble(loc.x);
+      drag_y->setDouble(loc.y);
+      event->accept();
+    } else if (calib_drag_x != nullptr && calib_drag_y != nullptr) {
+      calib_drag_x->setDouble(loc.x);
+      calib_drag_y->setDouble(loc.y);
+      event->accept();
+    }
   }
   else
     event->ignore();

--- a/src/app/plugins/plugin_cameracalib.h
+++ b/src/app/plugins/plugin_cameracalib.h
@@ -46,9 +46,10 @@ protected:
   int video_width;
   int video_height;
 
-  bool doing_drag;
   VarDouble* drag_x;
   VarDouble* drag_y;
+  VarDouble* calib_drag_x;
+  VarDouble* calib_drag_y;
 
   void sanitizeSobel(greyImage * img, GVector::vector2d<double> & val,int sobel_border=1);
 

--- a/src/app/plugins/plugin_cameracalib.h
+++ b/src/app/plugins/plugin_cameracalib.h
@@ -45,7 +45,6 @@ protected:
   rgbImage* rgb_image;
   int video_width;
   int video_height;
-  void mouseEvent ( QMouseEvent * event, pixelloc loc );
 
   bool doing_drag;
   VarDouble* drag_x;

--- a/src/app/plugins/plugin_visualize.cpp
+++ b/src/app/plugins/plugin_visualize.cpp
@@ -221,7 +221,7 @@ void PluginVisualize::DrawCameraCalibration(
     int size = 3;
     int sizeFat = 11;
     const rgb color = RGB::Pink;
-    for (const auto &point : camera_parameters.extrinsic_parameters->calib_image_points) {
+    for (const auto &point : camera_parameters.extrinsic_parameters->getCalibImagePoints()) {
       int px = (int) point.x - size/2;
       int py = (int) point.y - size/2;
       vis_frame->data.drawBox(px, py, size, size, color);

--- a/src/app/plugins/plugin_visualize.cpp
+++ b/src/app/plugins/plugin_visualize.cpp
@@ -123,6 +123,7 @@ void PluginVisualize::DrawCameraImage(
   }
   if (_v_chessboard->getBool()) {
     DrawChessboard(data, vis_frame);
+    DrawChessboardCalibrationPoints(data, vis_frame);
   }
 }
 
@@ -546,9 +547,9 @@ void PluginVisualize::drawFieldLine(
 void PluginVisualize::DrawChessboard(FrameData *data,
                                      VisualizationFrame *vis_frame) {
   Chessboard *chessboard;
-  if ((chessboard = reinterpret_cast<Chessboard*>(
-      data->map.get("chessboard"))) == nullptr) {
+  if ((chessboard = reinterpret_cast<Chessboard*>(data->map.get("chessboard"))) == nullptr) {
     std::cerr << "chessboard_found key missing from data map.\n";
+    return;
   }
 
   cv::Mat chessboard_img(vis_frame->data.getHeight(),
@@ -557,4 +558,21 @@ void PluginVisualize::DrawChessboard(FrameData *data,
 
   cv::drawChessboardCorners(chessboard_img, chessboard->pattern_size, chessboard->corners,
                             chessboard->pattern_was_found);
+}
+
+void PluginVisualize::DrawChessboardCalibrationPoints(FrameData *data, VisualizationFrame *vis_frame) {
+  std::vector<std::vector<cv::Point2f>> *chessboard_img_points;
+  if ((chessboard_img_points = reinterpret_cast<std::vector<std::vector<cv::Point2f>> *>(data->map.get("chessboard_img_points"))) == nullptr) {
+    return;
+  }
+
+  int size = 3;
+  const rgb color = RGB::Blue;
+  for (const auto &points : *chessboard_img_points) {
+    for (const auto &point : points) {
+      int x = (int) point.x - size/2;
+      int y = (int) point.y - size/2;
+      vis_frame->data.drawBox(x, y, size, size, color);
+    }
+  }
 }

--- a/src/app/plugins/plugin_visualize.cpp
+++ b/src/app/plugins/plugin_visualize.cpp
@@ -216,6 +216,20 @@ void PluginVisualize::DrawCameraCalibration(
     std::string description = buff;
     vis_frame->data.drawString(bx + 10, by - 2, description, cpoint_draw_color);
   }
+
+  if (camera_parameters.use_opencv_model->getBool()) {
+    int size = 3;
+    int sizeFat = 11;
+    const rgb color = RGB::Pink;
+    for (const auto &point : camera_parameters.extrinsic_parameters->calib_image_points) {
+      int px = (int) point.x - size/2;
+      int py = (int) point.y - size/2;
+      vis_frame->data.drawBox(px, py, size, size, color);
+      int pfx = (int) point.x - sizeFat/2;
+      int pfy = (int) point.y - sizeFat/2;
+      vis_frame->data.drawFatBox(pfx, pfy, sizeFat, sizeFat, color);
+    }
+  }
 }
 
 void PluginVisualize::DrawCalibrationResult(

--- a/src/app/plugins/plugin_visualize.cpp
+++ b/src/app/plugins/plugin_visualize.cpp
@@ -353,9 +353,10 @@ void PluginVisualize::DrawDetectedEdges(
   for (size_t ls = 0; ls < camera_parameters.calibrationSegments.size(); ++ls) {
     const CameraParameters::CalibrationData& segment =
         camera_parameters.calibrationSegments[ls];
-    for(unsigned int edge=0; edge<segment.imgPts.size(); ++edge) {
-      if (!(segment.imgPts[edge].second)) continue;
-      const GVector::vector2d<double>& image_point = segment.imgPts[edge].first;
+    for(unsigned int edge=0; edge<segment.points.size(); ++edge) {
+      if (!(segment.points[edge].detected)) continue;
+      const GVector::vector2d<double>& image_point = segment.points[edge].img_point;
+      const GVector::vector2d<double>& image_closest_point = segment.points[edge].img_closestPointToSegment;
       vis_frame->data.drawBox(
           image_point.x - 5, image_point.y - 5, 11, 11, edge_draw_color);
       const double alpha = segment.alphas[edge];
@@ -366,6 +367,13 @@ void PluginVisualize::DrawDetectedEdges(
             (segment.p2 - segment.p1).norm();
         DrawEdgeTangent(image_point, field_point, field_tangent, vis_frame,
                         edge_draw_color);
+        if (image_closest_point.nonzero()) {
+          vis_frame->data.drawLine((int)image_point.x,
+                                   (int)image_point.y,
+                                   (int)image_closest_point.x,
+                                   (int)image_closest_point.y,
+                                   RGB::Pink);
+        }
       } else {
         const double angle =
             alpha * segment.theta1 + (1.0 - alpha) * segment.theta2;

--- a/src/app/plugins/plugin_visualize.cpp
+++ b/src/app/plugins/plugin_visualize.cpp
@@ -41,6 +41,7 @@ PluginVisualize::PluginVisualize(
   _v_thresholded = new VarBool("thresholded", true);
   _v_blobs = new VarBool("blobs", true);
   _v_camera_calibration = new VarBool("camera calibration", true);
+  _v_camera_calibration_markers = new VarBool("camera calibration markers", false);
   _v_calibration_result = new VarBool("calibration result", true);
   _v_calibration_result_pillars = new VarBool("calibration result pillars", false);
   _v_calibration_result_pillars_height = new VarDouble("calibration result pillars height", 150.0);
@@ -58,6 +59,7 @@ PluginVisualize::PluginVisualize(
   _settings->addChild(_v_thresholded);
   _settings->addChild(_v_blobs);
   _settings->addChild(_v_camera_calibration);
+  _settings->addChild(_v_camera_calibration_markers);
   _settings->addChild(_v_calibration_result);
   _settings->addChild(_v_calibration_result_pillars);
   _settings->addChild(_v_calibration_result_pillars_height);
@@ -216,7 +218,10 @@ void PluginVisualize::DrawCameraCalibration(
     std::string description = buff;
     vis_frame->data.drawString(bx + 10, by - 2, description, cpoint_draw_color);
   }
+}
 
+void PluginVisualize::DrawCameraCalibrationMarkers(
+    FrameData* data, VisualizationFrame* vis_frame) {
   if (camera_parameters.use_opencv_model->getBool()) {
     int size = 3;
     int sizeFat = 11;
@@ -231,6 +236,7 @@ void PluginVisualize::DrawCameraCalibration(
     }
   }
 }
+
 
 void PluginVisualize::DrawCalibrationResult(
     FrameData* data, VisualizationFrame* vis_frame) {
@@ -487,6 +493,11 @@ ProcessResult PluginVisualize::process(
     // Camera calibration
     if (_v_camera_calibration->getBool()) {
       DrawCameraCalibration(data, vis_frame);
+    }
+
+    // Camera calibration
+    if (_v_camera_calibration_markers->getBool()) {
+      DrawCameraCalibrationMarkers(data, vis_frame);
     }
 
     // Result of camera calibration, draws field to image

--- a/src/app/plugins/plugin_visualize.h
+++ b/src/app/plugins/plugin_visualize.h
@@ -62,9 +62,12 @@ protected:
   VarBool * _v_blobs;
   VarBool * _v_camera_calibration;
   VarBool * _v_calibration_result;
+  VarBool * _v_calibration_result_pillars;
+  VarDouble * _v_calibration_result_pillars_height;
   VarBool * _v_complete_sobel;
   VarBool * _v_detected_edges;
   VarBool * _v_mask_hull;
+  VarBool * _v_chessboard;
 
   const CameraParameters& camera_parameters;
   const RoboCupField& real_field;
@@ -108,16 +111,18 @@ protected:
   void DrawSearchCorridors(FrameData* data, VisualizationFrame* vis_frame);
 
   void DrawMaskHull(FrameData* data, VisualizationFrame* vis_frame);
+
+  static void DrawChessboard(FrameData* data, VisualizationFrame* vis_frame);
 public:
   PluginVisualize(FrameBuffer* _buffer, const CameraParameters& camera_params,
                   const RoboCupField& real_field, const ConvexHullImageMask &mask);
 
-  ~PluginVisualize();
+  ~PluginVisualize() override;
 
    void setThresholdingLUT(LUT3D * threshold_lut);
-   virtual ProcessResult process(FrameData * data, RenderOptions * options);
-   virtual VarList * getSettings();
-   virtual string getName();
+   ProcessResult process(FrameData * data, RenderOptions * options) override;
+   VarList * getSettings() override;
+   string getName() override;
 };
 
 #endif

--- a/src/app/plugins/plugin_visualize.h
+++ b/src/app/plugins/plugin_visualize.h
@@ -61,6 +61,7 @@ protected:
   VarBool * _v_thresholded;
   VarBool * _v_blobs;
   VarBool * _v_camera_calibration;
+  VarBool * _v_camera_calibration_markers;
   VarBool * _v_calibration_result;
   VarBool * _v_calibration_result_pillars;
   VarDouble * _v_calibration_result_pillars_height;
@@ -95,6 +96,7 @@ protected:
   void DrawBlobs(FrameData* data, VisualizationFrame* vis_frame);
 
   void DrawCameraCalibration(FrameData* data, VisualizationFrame* vis_frame);
+  void DrawCameraCalibrationMarkers(FrameData* data, VisualizationFrame* vis_frame);
 
   void DrawCalibrationResult(FrameData* data, VisualizationFrame* vis_frame);
 

--- a/src/app/plugins/plugin_visualize.h
+++ b/src/app/plugins/plugin_visualize.h
@@ -113,6 +113,7 @@ protected:
   void DrawMaskHull(FrameData* data, VisualizationFrame* vis_frame);
 
   static void DrawChessboard(FrameData* data, VisualizationFrame* vis_frame);
+  static void DrawChessboardCalibrationPoints(FrameData* data, VisualizationFrame* vis_frame);
 public:
   PluginVisualize(FrameBuffer* _buffer, const CameraParameters& camera_params,
                   const RoboCupField& real_field, const ConvexHullImageMask &mask);

--- a/src/app/stacks/stack_robocup_ssl.cpp
+++ b/src/app/stacks/stack_robocup_ssl.cpp
@@ -19,6 +19,7 @@
 */
 //========================================================================
 #include "stack_robocup_ssl.h"
+#include <plugin_camera_intrinsic_calib.h>
 
 StackRoboCupSSL::StackRoboCupSSL(
     RenderOptions * _opts,
@@ -69,6 +70,9 @@ StackRoboCupSSL::StackRoboCupSSL(
   stack.push_back(new PluginCameraCalibration(_fb,*camera_parameters, *global_field));
 
   stack.push_back(new PluginColorThreshold(_fb,lut_yuv, *_image_mask));
+
+  stack.push_back(
+      new PluginCameraIntrinsicCalibration(_fb, *camera_parameters));
 
   stack.push_back(new PluginRunlengthEncode(_fb));
 

--- a/src/app/stacks/stack_robocup_ssl.h
+++ b/src/app/stacks/stack_robocup_ssl.h
@@ -24,6 +24,7 @@
 #include "visionstack.h"
 #include "lut3d.h"
 #include "camera_calibration.h"
+#include "camera_parameters.h"
 #include "field.h"
 #include "plugin_dvr.h"
 #include "plugin_colorcalib.h"
@@ -84,7 +85,7 @@ class StackRoboCupSSL : public VisionStack {
                   RoboCupSSLServer* ds_udp_server_old,
                   string cam_settings_filename);
   virtual string getSettingsFileName();
-  virtual ~StackRoboCupSSL();
+  ~StackRoboCupSSL() override;
 };
 
 

--- a/src/shared/CMakeLists.txt.inc
+++ b/src/shared/CMakeLists.txt.inc
@@ -35,7 +35,9 @@ set (SHARED_SRCS
 
 	${shared_dir}/util/affinity_manager.cpp
 	${shared_dir}/util/camera_calibration.cpp
+	${shared_dir}/util/camera_parameters.cpp
 	${shared_dir}/util/conversions.cpp
+	${shared_dir}/util/conversions_greyscale.cpp
 	${shared_dir}/util/global_random.cpp
 	${shared_dir}/util/image.cpp
 	${shared_dir}/util/image_io.cpp

--- a/src/shared/util/camera_calibration.cpp
+++ b/src/shared/util/camera_calibration.cpp
@@ -736,15 +736,31 @@ void CameraParameters::detectCalibrationCorners() {
 
       cv::Rect2d rect_line1(lines_start[i], lines_end[i]);
       cv::Rect2d rect_line2(lines_start[j], lines_end[j]);
-      if (found_img &&
-          found_field
+      if (found_img
+          && found_field
           // check if intersection is on line segment
-          && contains(rect_line1, p_intersection_field, 10) && contains(rect_line2, p_intersection_field, 10)) {
+          && contains(rect_line1, p_intersection_field, 10)
+          && contains(rect_line2, p_intersection_field, 10)
+          && p_intersection_img_undistorted.x >= 0
+          && p_intersection_img_undistorted.y >= 0
+          && p_intersection_img_undistorted.x < additional_calibration_information->imageWidth->getInt()
+          && p_intersection_img_undistorted.y < additional_calibration_information->imageHeight->getInt()) {
         cv::Point3d p_intersection_img_undistorted_3d(
             p_intersection_img_undistorted.x, p_intersection_img_undistorted.y, 0);
         points_intersection_img_undistorted.push_back(p_intersection_img_undistorted_3d);
         cv::Point3d p_intersection_field_3d(p_intersection_field.x, p_intersection_field.y, 0);
         points_intersection_field.push_back(p_intersection_field_3d);
+      } else {
+        std::cout << "No calibration points found for "
+            << line_field1 << " -> " << line_field2
+            << "( " << line_img1 << " -> " << line_img2 << " )"
+            << std::endl
+            << "found_img: " << found_img
+            << "found_field: " << found_field
+            << std::endl
+            << "intersection img: " << p_intersection_img_undistorted
+            << "intersection_field: " << p_intersection_field
+            << std::endl;
       }
     }
   }

--- a/src/shared/util/camera_calibration.cpp
+++ b/src/shared/util/camera_calibration.cpp
@@ -736,11 +736,7 @@ void CameraParameters::detectCalibrationCorners() {
           && found_field
           // check if intersection is on line segment
           && contains(rect_line1, p_intersection_field, 10)
-          && contains(rect_line2, p_intersection_field, 10)
-          && p_intersection_img_undistorted.x >= 0
-          && p_intersection_img_undistorted.y >= 0
-          && p_intersection_img_undistorted.x < additional_calibration_information->imageWidth->getInt()
-          && p_intersection_img_undistorted.y < additional_calibration_information->imageHeight->getInt()) {
+          && contains(rect_line2, p_intersection_field, 10)) {
         cv::Point3d p_intersection_img_undistorted_3d(
             p_intersection_img_undistorted.x, p_intersection_img_undistorted.y, 0);
         points_intersection_img_undistorted.push_back(p_intersection_img_undistorted_3d);
@@ -771,7 +767,16 @@ void CameraParameters::detectCalibrationCorners() {
                       intrinsic_parameters->dist_coeffs,
                       points_img_intersect);
     for (int i = 0; i < (int) points_img_intersect.size(); i++) {
-      extrinsic_parameters->addCalibrationPointSet(points_img_intersect[i], points_intersection_field[i]);
+      if (points_img_intersect[i].x >= 0
+         && points_img_intersect[i].y >= 0
+         && points_img_intersect[i].x < additional_calibration_information->imageWidth->getInt()
+         && points_img_intersect[i].y < additional_calibration_information->imageHeight->getInt()) {
+        extrinsic_parameters->addCalibrationPointSet(points_img_intersect[i], points_intersection_field[i]);
+      } else {
+        std::cout << "Calibration point outside image: "
+          << points_img_intersect[i]
+          << std::endl;
+      }
     }
   }
 }

--- a/src/shared/util/camera_calibration.cpp
+++ b/src/shared/util/camera_calibration.cpp
@@ -586,23 +586,19 @@ void CameraParameters::calibrateExtrinsicModel(
     std::vector<GVector::vector2d<double>> &p_i,
     int cal_type) const {
 
-    std::vector<cv::Point3d> calib_field_points;
-    std::vector<cv::Point2d> calib_image_points;
+  std::vector<cv::Point3d> calib_field_points = extrinsic_parameters->getCalibFieldPoints();
+  std::vector<cv::Point2d> calib_image_points = extrinsic_parameters->getCalibImagePoints();
 
-  if (cal_type & FOUR_POINT_INITIAL) {
+  if (cal_type & FULL_ESTIMATION && calib_field_points.size() < 4) {
+    std::cerr << "Not enough calibration points for full estimation: " << calib_field_points.size() << std::endl;
+  }
+
+  if (cal_type & FOUR_POINT_INITIAL || calib_field_points.size() < 4) {
     // Use calibration points
     for (uint i = 0; i < p_f.size(); i++) {
       calib_field_points.emplace_back(p_f[i].x, p_f[i].y, p_f[i].z);
       calib_image_points.emplace_back(p_i[i].x, p_i[i].y);
     }
-  } else {
-    calib_field_points = extrinsic_parameters->getCalibFieldPoints();
-    calib_image_points = extrinsic_parameters->getCalibImagePoints();
-  }
-
-  if (calib_field_points.size() < 4) {
-    std::cerr << "Not enough calibration points: " << calib_field_points.size() << std::endl;
-    return;
   }
 
   std::vector<std::vector<cv::Point3f>> object_points(1);
@@ -753,13 +749,13 @@ void CameraParameters::detectCalibrationCorners() {
       } else {
         std::cout << "No calibration points found for "
             << line_field1 << " -> " << line_field2
-            << "( " << line_img1 << " -> " << line_img2 << " )"
+            << " ( " << line_img1 << " -> " << line_img2 << " )"
             << std::endl
             << "found_img: " << found_img
-            << "found_field: " << found_field
+            << " found_field: " << found_field
             << std::endl
             << "intersection img: " << p_intersection_img_undistorted
-            << "intersection_field: " << p_intersection_field
+            << " intersection_field: " << p_intersection_field
             << std::endl;
       }
     }

--- a/src/shared/util/camera_calibration.h
+++ b/src/shared/util/camera_calibration.h
@@ -80,10 +80,10 @@ class CameraParameters {
   GVector::vector3d<double> getWorldLocation() const;
   void field2image(const GVector::vector3d<double>& p_f, GVector::vector2d<double>& p_i) const;
   void image2field(GVector::vector3d<double>& p_f, const GVector::vector2d<double>& p_i, double z) const;
-  void calibrate(std::vector<GVector::vector3d<double> >& p_f,
+  double calibrate(std::vector<GVector::vector3d<double> >& p_f,
                  std::vector<GVector::vector2d<double> >& p_i,
                  int cal_type);
-  void calibrateExtrinsicModel(std::vector<GVector::vector3d<double> >& p_f,
+  double calibrateExtrinsicModel(std::vector<GVector::vector3d<double> >& p_f,
                                std::vector<GVector::vector2d<double> >& p_i,
                                int cal_type);
 
@@ -201,7 +201,7 @@ class CameraParameters {
   };
 
  public:
-  void do_calibration(int cal_type);
+  double do_calibration(int cal_type);
   void reset() const;
 };
 

--- a/src/shared/util/camera_calibration.h
+++ b/src/shared/util/camera_calibration.h
@@ -85,7 +85,7 @@ class CameraParameters {
                  int cal_type);
   double calibrateExtrinsicModel(std::vector<GVector::vector3d<double> >& p_f,
                                std::vector<GVector::vector2d<double> >& p_i,
-                               int cal_type);
+                               int cal_type) const;
 
   /** apply radial distortion to (undistorted) radius ru and return distorted radius */
   double radialDistortion(double ru) const;
@@ -203,6 +203,7 @@ class CameraParameters {
  public:
   double do_calibration(int cal_type);
   void reset() const;
+  void detectCalibrationCorners();
 };
 
 #endif

--- a/src/shared/util/camera_calibration.h
+++ b/src/shared/util/camera_calibration.h
@@ -25,12 +25,14 @@
 #include <VarDouble.h>
 #include <VarList.h>
 #include <quaternion.h>
+
 #include <Eigen/Core>
-#include "field.h"
-#include "timer.h"
 #include <opencv2/opencv.hpp>
+
 #include "camera_parameters.h"
+#include "field.h"
 #include "messages_robocup_ssl_geometry.pb.h"
+#include "timer.h"
 
 /*!
   \class CameraParameters
@@ -39,16 +41,14 @@
 
   \author Tim Laue, (C) 2009
 **/
-class CameraParameters
-{
-public:
-
+class CameraParameters {
+ public:
   class AdditionalCalibrationInformation;
   class CalibrationData;
 
-  CameraParameters(int camera_index_, RoboCupField * field);
+  CameraParameters(int camera_index_, RoboCupField* field);
   ~CameraParameters();
-  void addSettingsToList(VarList& list);
+  void addSettingsToList(VarList& list) const;
 
   VarDouble* focal_length;
   VarDouble* principal_point_x;
@@ -78,40 +78,35 @@ public:
 
   void quaternionFromOpenCVCalibration(double Q[]) const;
   GVector::vector3d<double> getWorldLocation() const;
-  void field2image(const GVector::vector3d<double> &p_f, GVector::vector2d<double> &p_i) const;
-  void image2field(GVector::vector3d< double >& p_f, const GVector::vector2d< double >& p_i, double z) const;
-  void calibrate(std::vector<GVector::vector3d<double> > &p_f, std::vector<GVector::vector2d<double> > &p_i, int cal_type);
-  void calibrateExtrinsicModel(std::vector<GVector::vector3d<double> > &p_f, std::vector<GVector::vector2d<double> > &p_i, int cal_type);
+  void field2image(const GVector::vector3d<double>& p_f, GVector::vector2d<double>& p_i) const;
+  void image2field(GVector::vector3d<double>& p_f, const GVector::vector2d<double>& p_i, double z) const;
+  void calibrate(std::vector<GVector::vector3d<double> >& p_f,
+                 std::vector<GVector::vector2d<double> >& p_i,
+                 int cal_type);
+  void calibrateExtrinsicModel(std::vector<GVector::vector3d<double> >& p_f,
+                               std::vector<GVector::vector2d<double> >& p_i,
+                               int cal_type);
 
-  double radialDistortion(double ru) const;  //apply radial distortion to (undistorted) radius ru and return distorted radius
-  double radialDistortionInv(double rd) const;  //invert radial distortion from (distorted) radius rd and return undistorted radius
-  void radialDistortionInv(GVector::vector2d<double> &pu, const GVector::vector2d<double> &pd) const;
-  void radialDistortion(GVector::vector2d<double> pu, GVector::vector2d<double> &pd) const;
-  double radialDistortion(double ru, double dist) const;
-  void radialDistortion(GVector::vector2d<double> pu, GVector::vector2d<double> &pd, double dist) const;
+  /** apply radial distortion to (undistorted) radius ru and return distorted radius */
+  double radialDistortion(double ru) const;
+  /** invert radial distortion from (distorted) radius rd and return undistorted radius */
+  double radialDistortionInv(double rd) const;
+  void radialDistortionInv(GVector::vector2d<double>& pu, const GVector::vector2d<double>& pd) const;
+  void radialDistortion(GVector::vector2d<double> pu, GVector::vector2d<double>& pd) const;
+  static double radialDistortion(double ru, double dist);
+  static void radialDistortion(GVector::vector2d<double> pu, GVector::vector2d<double>& pd, double dist);
 
-  double calc_chisqr(std::vector<GVector::vector3d<double> > &p_f, std::vector<GVector::vector2d<double> > &p_i, Eigen::VectorXd &p, int);
-  void field2image(GVector::vector3d<double> &p_f, GVector::vector2d<double> &p_i, Eigen::VectorXd &p);
+  double calc_chisqr(std::vector<GVector::vector3d<double> >& p_f,
+                     std::vector<GVector::vector2d<double> >& p_i,
+                     Eigen::VectorXd& p,
+                     int);
+  void field2image(GVector::vector3d<double>& p_f, GVector::vector2d<double>& p_i, Eigen::VectorXd& p) const;
 
-  void toProtoBuffer(SSL_GeometryCameraCalibration &buffer) const;
+  void toProtoBuffer(SSL_GeometryCameraCalibration& buffer) const;
 
-  enum
-  {
-    FOCAL_LENGTH=0,
-    PP_X,
-    PP_Y,
-    DIST,
-    Q_1,
-    Q_2,
-    Q_3,
-    T_1,
-    T_2,
-    T_3,
-    STATE_SPACE_DIMENSION
-  };
+  enum { FOCAL_LENGTH = 0, PP_X, PP_Y, DIST, Q_1, Q_2, Q_3, T_1, T_2, T_3, STATE_SPACE_DIMENSION };
 
-  enum
-  {
+  enum {
     FOUR_POINT_INITIAL = 1,
     FULL_ESTIMATION = 2
     // ... = 4 etc.
@@ -124,45 +119,47 @@ public:
   \brief Some additional data used for calibration
   \author Tim Laue, (C) 2009
    **/
-  class AdditionalCalibrationInformation
-  {
-    public:
-      AdditionalCalibrationInformation(int camera_index_, RoboCupField* field);
-      ~AdditionalCalibrationInformation();
-      void addSettingsToList(VarList& list);
-      void updateControlPoints();
+  class AdditionalCalibrationInformation {
+   public:
+    AdditionalCalibrationInformation(int camera_index_, RoboCupField* field);
+    ~AdditionalCalibrationInformation();
+    void addSettingsToList(VarList& list);
+    void updateControlPoints();
 
-      static const int kNumControlPoints = 4;
-      VarInt* camera_index;
-      VarList* control_point_set[kNumControlPoints];
-      VarString* control_point_names[kNumControlPoints];
-      VarDouble* control_point_image_xs[kNumControlPoints];
-      VarDouble* control_point_image_ys[kNumControlPoints];
-      VarDouble* control_point_field_xs[kNumControlPoints];
-      VarDouble* control_point_field_ys[kNumControlPoints];
+    static const int kNumControlPoints = 4;
+    VarInt* camera_index;
+    VarList* control_point_set[kNumControlPoints]{};
+    VarString* control_point_names[kNumControlPoints]{};
+    VarDouble* control_point_image_xs[kNumControlPoints]{};
+    VarDouble* control_point_image_ys[kNumControlPoints]{};
+    VarDouble* control_point_field_xs[kNumControlPoints]{};
+    VarDouble* control_point_field_ys[kNumControlPoints]{};
 
-      VarDouble* initial_distortion;
-      VarDouble* line_search_corridor_width;
-      VarDouble* image_boundary;
-      VarDouble* max_feature_distance;
-      VarDouble* convergence_timeout;
-      VarDouble* cov_corner_x;
-      VarDouble* cov_corner_y;
+    VarDouble* initial_distortion;
+    VarDouble* line_search_corridor_width;
+    VarDouble* image_boundary;
+    VarDouble* max_feature_distance;
+    VarDouble* convergence_timeout;
+    VarDouble* cov_corner_x;
+    VarDouble* cov_corner_y;
 
-      VarDouble* cov_ls_x;
-      VarDouble* cov_ls_y;
+    VarDouble* cov_ls_x;
+    VarDouble* cov_ls_y;
 
-      VarDouble* pointSeparation;
+    VarDouble* pointSeparation;
 
-      VarInt* imageWidth;
-      VarInt* imageHeight;
-      VarInt* grid_width;
-      VarInt* grid_height;
-      VarInt *global_camera_id;
-  private:
-      RoboCupField* field;
-      std::vector<GVector::vector2d<double> >
-      generateCameraControlPoints(int cameraId, int numCamerasTotal, double fieldHeight, double fieldWidth);
+    VarInt* imageWidth;
+    VarInt* imageHeight;
+    VarInt* grid_width;
+    VarInt* grid_height;
+    VarInt* global_camera_id;
+
+   private:
+    RoboCupField* field;
+    static std::vector<GVector::vector2d<double> > generateCameraControlPoints(int cameraId,
+                                                                               int numCamerasTotal,
+                                                                               double fieldHeight,
+                                                                               double fieldWidth);
   };
 
   /*!
@@ -174,26 +171,26 @@ public:
   class CalibrationData {
    public:
     // False implies that it is an arc segment.
-    bool straightLine;
+    bool straightLine = true;
 
-    //Parameters for straight line segments
-    //Start point of the straight line segment in world space coords
+    // Parameters for straight line segments
+    // Start point of the straight line segment in world space coords
     GVector::vector3d<double> p1;
-    //End point of the straight line segment in world space coords
+    // End point of the straight line segment in world space coords
     GVector::vector3d<double> p2;
 
-    //Parameters for arc segments
-    //center point of the arc segment in world space coords
+    // Parameters for arc segments
+    // center point of the arc segment in world space coords
     GVector::vector3d<double> center;
-    //Start angle (Counter-clockwise, right-handed system) of the arc in world space
+    // Start angle (Counter-clockwise, right-handed system) of the arc in world space
     double theta1;
-    //End angle (Counter-clockwise, right-handed system) of the arc in world space
+    // End angle (Counter-clockwise, right-handed system) of the arc in world space
     double theta2;
-    //Radius of the arc in world space
+    // Radius of the arc in world space
     double radius;
 
-    //Image points, paired with a bool indicating whether the point was correctly detected
-    std::vector<std::pair<GVector::vector2d<double>,bool> > imgPts;
+    // Image points, paired with a bool indicating whether the point was correctly detected
+    std::vector<std::pair<GVector::vector2d<double>, bool> > imgPts;
 
     // Denotes the position along the line or arc. For each point, the
     // location of the point is "alpha * start + (1.0 - alpha) * end" where
@@ -201,16 +198,11 @@ public:
     // segment. During calibration, this is varied to move the point along the
     // line / arc to minimize the fitting error - see how p_alpha varies.
     std::vector<double> alphas;
-
-    CalibrationData() {
-      straightLine = true;
-    }
   };
 
-
-public:
+ public:
   void do_calibration(int cal_type);
-  void reset();
+  void reset() const;
 };
 
 #endif

--- a/src/shared/util/camera_calibration.h
+++ b/src/shared/util/camera_calibration.h
@@ -80,12 +80,16 @@ class CameraParameters {
   GVector::vector3d<double> getWorldLocation() const;
   void field2image(const GVector::vector3d<double>& p_f, GVector::vector2d<double>& p_i) const;
   void image2field(GVector::vector3d<double>& p_f, const GVector::vector2d<double>& p_i, double z) const;
-  double calibrate(std::vector<GVector::vector3d<double> >& p_f,
+  void calibrate(std::vector<GVector::vector3d<double> >& p_f,
                  std::vector<GVector::vector2d<double> >& p_i,
                  int cal_type);
-  double calibrateExtrinsicModel(std::vector<GVector::vector3d<double> >& p_f,
+  void calibrateExtrinsicModel(std::vector<GVector::vector3d<double> >& p_f,
                                std::vector<GVector::vector2d<double> >& p_i,
                                int cal_type) const;
+  double calculateFourPointRmse(std::vector<GVector::vector3d<double> > &p_f,
+                                std::vector<GVector::vector2d<double> > &p_i) const;
+  void updateCalibrationDataPoints();
+  double calculateCalibrationDataPointsRmse();
 
   /** apply radial distortion to (undistorted) radius ru and return distorted radius */
   double radialDistortion(double ru) const;
@@ -162,6 +166,16 @@ class CameraParameters {
                                                                                double fieldWidth);
   };
 
+  class CalibrationDataPoint {
+   public:
+    CalibrationDataPoint(GVector::vector2d<double> img_point, bool detected);
+    bool detected;
+    GVector::vector2d<double> img_point = {};
+    GVector::vector2d<double> img_closestPointToSegment = {};
+    GVector::vector3d<double> world_point = {};
+    GVector::vector3d<double> world_closestPointToSegment = {};
+  };
+
   /*!
   \class CalibrationData
   \brief Additional structure for holding information about
@@ -190,7 +204,7 @@ class CameraParameters {
     double radius;
 
     // Image points, paired with a bool indicating whether the point was correctly detected
-    std::vector<std::pair<GVector::vector2d<double>, bool> > imgPts;
+    std::vector<CalibrationDataPoint> points;
 
     // Denotes the position along the line or arc. For each point, the
     // location of the point is "alpha * start + (1.0 - alpha) * end" where

--- a/src/shared/util/camera_calibration.h
+++ b/src/shared/util/camera_calibration.h
@@ -19,20 +19,18 @@
 */
 //========================================================================
 
+#ifndef CAMERA_CALIBRATION_H
+#define CAMERA_CALIBRATION_H
+
 #include <VarDouble.h>
 #include <VarList.h>
 #include <quaternion.h>
 #include <Eigen/Core>
 #include "field.h"
 #include "timer.h"
-
-#ifndef CAMERA_CALIBRATION_H
-#define CAMERA_CALIBRATION_H
+#include <opencv2/opencv.hpp>
+#include "camera_parameters.h"
 #include "messages_robocup_ssl_geometry.pb.h"
-
-
-//using namespace Eigen;
-//USING_PART_OF_NAMESPACE_EIGEN
 
 /*!
   \class CameraParameters
@@ -72,22 +70,25 @@ public:
   Eigen::VectorXd p_alpha;
   Quaternion<double> q_rotate180;
 
-  //Quaternion<double> q_field2cam;
-  //GVector::vector3d<double> translation;
-
   AdditionalCalibrationInformation* additional_calibration_information;
 
-  GVector::vector3d<double> getWorldLocation();
+  VarBool* use_opencv_model;
+  CameraIntrinsicParameters* intrinsic_parameters;
+  CameraExtrinsicParameters* extrinsic_parameters;
+
+  void quaternionFromOpenCVCalibration(double Q[]) const;
+  GVector::vector3d<double> getWorldLocation() const;
   void field2image(const GVector::vector3d<double> &p_f, GVector::vector2d<double> &p_i) const;
   void image2field(GVector::vector3d< double >& p_f, const GVector::vector2d< double >& p_i, double z) const;
   void calibrate(std::vector<GVector::vector3d<double> > &p_f, std::vector<GVector::vector2d<double> > &p_i, int cal_type);
+  void calibrateExtrinsicModel(std::vector<GVector::vector3d<double> > &p_f, std::vector<GVector::vector2d<double> > &p_i, int cal_type);
 
   double radialDistortion(double ru) const;  //apply radial distortion to (undistorted) radius ru and return distorted radius
   double radialDistortionInv(double rd) const;  //invert radial distortion from (distorted) radius rd and return undistorted radius
   void radialDistortionInv(GVector::vector2d<double> &pu, const GVector::vector2d<double> &pd) const;
-  void radialDistortion(const GVector::vector2d<double> pu, GVector::vector2d<double> &pd) const;
+  void radialDistortion(GVector::vector2d<double> pu, GVector::vector2d<double> &pd) const;
   double radialDistortion(double ru, double dist) const;
-  void radialDistortion(const GVector::vector2d<double> pu, GVector::vector2d<double> &pd, double dist) const;
+  void radialDistortion(GVector::vector2d<double> pu, GVector::vector2d<double> &pd, double dist) const;
 
   double calc_chisqr(std::vector<GVector::vector3d<double> > &p_f, std::vector<GVector::vector2d<double> > &p_i, Eigen::VectorXd &p, int);
   void field2image(GVector::vector3d<double> &p_f, GVector::vector2d<double> &p_i, Eigen::VectorXd &p);
@@ -155,6 +156,9 @@ public:
 
       VarInt* imageWidth;
       VarInt* imageHeight;
+      VarInt* grid_width;
+      VarInt* grid_height;
+      VarInt *global_camera_id;
   private:
       RoboCupField* field;
       std::vector<GVector::vector2d<double> >

--- a/src/shared/util/camera_parameters.cpp
+++ b/src/shared/util/camera_parameters.cpp
@@ -1,0 +1,186 @@
+#include "camera_parameters.h"
+
+#include <VarList.h>
+
+CameraIntrinsicParameters::CameraIntrinsicParameters() {
+  settings = new VarList("Intrinsic Parameters");
+
+  focal_length_x = new VarDouble("focal_length_x", 1.0);
+  focal_length_y = new VarDouble("focal_length_y", 1.0);
+  principal_point_x = new VarDouble("principal_point_x", 0.0);
+  principal_point_y = new VarDouble("principal_point_y", 0.0);
+
+  dist_coeff_k1 = new VarDouble("dist_coeff_k1", 0.0);
+  dist_coeff_k2 = new VarDouble("dist_coeff_k2", 0.0);
+  dist_coeff_p1 = new VarDouble("dist_coeff_p1", 0.0);
+  dist_coeff_p2 = new VarDouble("dist_coeff_p2", 0.0);
+  dist_coeff_k3 = new VarDouble("dist_coeff_k3", 0.0);
+
+  settings->addChild(focal_length_x);
+  settings->addChild(focal_length_y);
+  settings->addChild(principal_point_x);
+  settings->addChild(principal_point_y);
+  settings->addChild(dist_coeff_k1);
+  settings->addChild(dist_coeff_k2);
+  settings->addChild(dist_coeff_p1);
+  settings->addChild(dist_coeff_p2);
+  settings->addChild(dist_coeff_k3);
+
+  connect(focal_length_x, SIGNAL(hasChanged(VarType*)), this, SLOT(updateCameraMat()));
+  connect(focal_length_y, SIGNAL(hasChanged(VarType*)), this, SLOT(updateCameraMat()));
+  connect(principal_point_x, SIGNAL(hasChanged(VarType*)), this, SLOT(updateCameraMat()));
+  connect(principal_point_y, SIGNAL(hasChanged(VarType*)), this, SLOT(updateCameraMat()));
+
+  connect(dist_coeff_k1, SIGNAL(hasChanged(VarType*)), this, SLOT(updateDistCoeffs()));
+  connect(dist_coeff_k2, SIGNAL(hasChanged(VarType*)), this, SLOT(updateDistCoeffs()));
+  connect(dist_coeff_p1, SIGNAL(hasChanged(VarType*)), this, SLOT(updateDistCoeffs()));
+  connect(dist_coeff_p2, SIGNAL(hasChanged(VarType*)), this, SLOT(updateDistCoeffs()));
+  connect(dist_coeff_k3, SIGNAL(hasChanged(VarType*)), this, SLOT(updateDistCoeffs()));
+
+  camera_mat = cv::Mat::eye(3, 3, CV_64FC1);
+  dist_coeffs = cv::Mat(5, 1, CV_64FC1, cv::Scalar(0));
+  updateCameraMat();
+  updateDistCoeffs();
+}
+
+CameraIntrinsicParameters::~CameraIntrinsicParameters() {
+  delete focal_length_x;
+  delete focal_length_y;
+  delete principal_point_x;
+  delete principal_point_y;
+  delete dist_coeff_k1;
+  delete dist_coeff_k2;
+  delete dist_coeff_p1;
+  delete dist_coeff_p2;
+  delete dist_coeff_k3;
+  delete settings;
+}
+
+void CameraIntrinsicParameters::updateCameraMat() {
+  camera_mat.at<double>(0, 0) = focal_length_x->getDouble();
+  camera_mat.at<double>(1, 1) = focal_length_y->getDouble();
+  camera_mat.at<double>(0, 2) = principal_point_x->getDouble();
+  camera_mat.at<double>(1, 2) = principal_point_y->getDouble();
+
+  camera_mat_inv = camera_mat.inv();
+}
+
+void CameraIntrinsicParameters::updateDistCoeffs() {
+  dist_coeffs.at<double>(0, 0) = dist_coeff_k1->getDouble();
+  dist_coeffs.at<double>(1, 0) = dist_coeff_k2->getDouble();
+  dist_coeffs.at<double>(2, 0) = dist_coeff_p1->getDouble();
+  dist_coeffs.at<double>(3, 0) = dist_coeff_p2->getDouble();
+  dist_coeffs.at<double>(4, 0) = dist_coeff_k3->getDouble();
+}
+
+void CameraIntrinsicParameters::updateConfigValues() const {
+  cv::Mat new_camera_mat(camera_mat);
+  focal_length_x->setDouble(new_camera_mat.at<double>(0, 0));
+  focal_length_y->setDouble(new_camera_mat.at<double>(1, 1));
+  principal_point_x->setDouble(new_camera_mat.at<double>(0, 2));
+  principal_point_y->setDouble(new_camera_mat.at<double>(1, 2));
+
+  cv::Mat new_dist_coeffs(dist_coeffs);
+  dist_coeff_k1->setDouble(new_dist_coeffs.at<double>(0, 0));
+  dist_coeff_k2->setDouble(new_dist_coeffs.at<double>(1, 0));
+  dist_coeff_p1->setDouble(new_dist_coeffs.at<double>(2, 0));
+  dist_coeff_p2->setDouble(new_dist_coeffs.at<double>(3, 0));
+  dist_coeff_k3->setDouble(new_dist_coeffs.at<double>(4, 0));
+}
+
+void CameraIntrinsicParameters::reset() {
+  focal_length_x->resetToDefault();
+  focal_length_y->resetToDefault();
+  principal_point_x->resetToDefault();
+  principal_point_y->resetToDefault();
+  updateCameraMat();
+
+  dist_coeff_k1->resetToDefault();
+  dist_coeff_k2->resetToDefault();
+  dist_coeff_p1->resetToDefault();
+  dist_coeff_p2->resetToDefault();
+  dist_coeff_k3->resetToDefault();
+  updateDistCoeffs();
+}
+
+CameraExtrinsicParameters::CameraExtrinsicParameters() {
+  settings = new VarList("Extrinsic Parameters");
+  rvec_x = new VarDouble("rvec x", 0.0);
+  rvec_y = new VarDouble("rvec y", 0.0);
+  rvec_z = new VarDouble("rvec z", 0.0);
+  tvec_x = new VarDouble("tvec x", 0.0);
+  tvec_y = new VarDouble("tvec y", 0.0);
+  tvec_z = new VarDouble("tvec z", 0.0);
+
+  settings->addChild(rvec_x);
+  settings->addChild(rvec_y);
+  settings->addChild(rvec_z);
+  settings->addChild(tvec_x);
+  settings->addChild(tvec_y);
+  settings->addChild(tvec_z);
+
+  connect(rvec_x, SIGNAL(hasChanged(VarType*)), this, SLOT(updateRVec()));
+  connect(rvec_y, SIGNAL(hasChanged(VarType*)), this, SLOT(updateRVec()));
+  connect(rvec_z, SIGNAL(hasChanged(VarType*)), this, SLOT(updateRVec()));
+  connect(tvec_x, SIGNAL(hasChanged(VarType*)), this, SLOT(updateTVec()));
+  connect(tvec_y, SIGNAL(hasChanged(VarType*)), this, SLOT(updateTVec()));
+  connect(tvec_z, SIGNAL(hasChanged(VarType*)), this, SLOT(updateTVec()));
+
+  rvec = cv::Mat(3, 1, CV_64FC1, cv::Scalar(0));
+  tvec = cv::Mat(3, 1, CV_64FC1, cv::Scalar(0));
+  rotation_mat_inv = cv::Mat(3, 3, CV_64FC1, cv::Scalar(0));
+  right_side_mat = cv::Mat(3, 1, CV_64FC1, cv::Scalar(0));
+}
+
+CameraExtrinsicParameters::~CameraExtrinsicParameters() {
+  delete rvec_x;
+  delete rvec_y;
+  delete rvec_z;
+  delete tvec_x;
+  delete tvec_y;
+  delete tvec_z;
+  delete settings;
+}
+
+void CameraExtrinsicParameters::updateTVec() {
+  tvec.at<double>(0, 0) = tvec_x->getDouble();
+  tvec.at<double>(0, 1) = tvec_y->getDouble();
+  tvec.at<double>(0, 2) = tvec_z->getDouble();
+
+  right_side_mat = rotation_mat_inv * tvec;
+}
+
+void CameraExtrinsicParameters::updateRVec() {
+  rvec.at<double>(0, 0) = rvec_x->getDouble();
+  rvec.at<double>(0, 1) = rvec_y->getDouble();
+  rvec.at<double>(0, 2) = rvec_z->getDouble();
+
+  cv::Mat rotation_mat(3, 3, cv::DataType<double>::type);
+  cv::Rodrigues(rvec, rotation_mat);
+  rotation_mat_inv = rotation_mat.inv();
+  right_side_mat = rotation_mat_inv * tvec;
+}
+
+void CameraExtrinsicParameters::updateConfigValues() {
+  cv::Mat new_tvec = tvec.clone();
+  tvec_x->setDouble(new_tvec.at<double>(0, 0));
+  tvec_y->setDouble(new_tvec.at<double>(0, 1));
+  tvec_z->setDouble(new_tvec.at<double>(0, 2));
+
+  cv::Mat new_rvec = rvec.clone();
+  rvec_x->setDouble(new_rvec.at<double>(0, 0));
+  rvec_y->setDouble(new_rvec.at<double>(0, 1));
+  rvec_z->setDouble(new_rvec.at<double>(0, 2));
+}
+
+void CameraExtrinsicParameters::reset() {
+  tvec_x->resetToDefault();
+  tvec_y->resetToDefault();
+  tvec_z->resetToDefault();
+  updateTVec();
+
+  rvec_x->resetToDefault();
+  rvec_y->resetToDefault();
+  rvec_z->resetToDefault();
+  updateRVec();
+}

--- a/src/shared/util/camera_parameters.cpp
+++ b/src/shared/util/camera_parameters.cpp
@@ -57,35 +57,41 @@ CameraIntrinsicParameters::~CameraIntrinsicParameters() {
 }
 
 void CameraIntrinsicParameters::updateCameraMat() {
-  camera_mat.at<double>(0, 0) = focal_length_x->getDouble();
-  camera_mat.at<double>(1, 1) = focal_length_y->getDouble();
-  camera_mat.at<double>(0, 2) = principal_point_x->getDouble();
-  camera_mat.at<double>(1, 2) = principal_point_y->getDouble();
+  cv::Mat tmp_camera_mat = cv::Mat::eye(3, 3, CV_64F);
+  tmp_camera_mat.at<double>(0, 0) = focal_length_x->getDouble();
+  tmp_camera_mat.at<double>(1, 1) = focal_length_y->getDouble();
+  tmp_camera_mat.at<double>(0, 2) = principal_point_x->getDouble();
+  tmp_camera_mat.at<double>(1, 2) = principal_point_y->getDouble();
+  tmp_camera_mat.copyTo(camera_mat);
 
   camera_mat_inv = camera_mat.inv();
 }
 
 void CameraIntrinsicParameters::updateDistCoeffs() {
-  dist_coeffs.at<double>(0, 0) = dist_coeff_k1->getDouble();
-  dist_coeffs.at<double>(1, 0) = dist_coeff_k2->getDouble();
-  dist_coeffs.at<double>(2, 0) = dist_coeff_p1->getDouble();
-  dist_coeffs.at<double>(3, 0) = dist_coeff_p2->getDouble();
-  dist_coeffs.at<double>(4, 0) = dist_coeff_k3->getDouble();
+  cv::Mat tmp_dist_coeffs(5, 1, CV_64F);
+  tmp_dist_coeffs.at<double>(0, 0) = dist_coeff_k1->getDouble();
+  tmp_dist_coeffs.at<double>(1, 0) = dist_coeff_k2->getDouble();
+  tmp_dist_coeffs.at<double>(2, 0) = dist_coeff_p1->getDouble();
+  tmp_dist_coeffs.at<double>(3, 0) = dist_coeff_p2->getDouble();
+  tmp_dist_coeffs.at<double>(4, 0) = dist_coeff_k3->getDouble();
+  tmp_dist_coeffs.copyTo(dist_coeffs);
 }
 
 void CameraIntrinsicParameters::updateConfigValues() const {
-  cv::Mat new_camera_mat(camera_mat);
-  focal_length_x->setDouble(new_camera_mat.at<double>(0, 0));
-  focal_length_y->setDouble(new_camera_mat.at<double>(1, 1));
-  principal_point_x->setDouble(new_camera_mat.at<double>(0, 2));
-  principal_point_y->setDouble(new_camera_mat.at<double>(1, 2));
+  cv::Mat tmp_camera_mat(3, 3, CV_64F);
+  camera_mat.copyTo(tmp_camera_mat);
+  focal_length_x->setDouble(tmp_camera_mat.at<double>(0, 0));
+  focal_length_y->setDouble(tmp_camera_mat.at<double>(1, 1));
+  principal_point_x->setDouble(tmp_camera_mat.at<double>(0, 2));
+  principal_point_y->setDouble(tmp_camera_mat.at<double>(1, 2));
 
-  cv::Mat new_dist_coeffs(dist_coeffs);
-  dist_coeff_k1->setDouble(new_dist_coeffs.at<double>(0, 0));
-  dist_coeff_k2->setDouble(new_dist_coeffs.at<double>(1, 0));
-  dist_coeff_p1->setDouble(new_dist_coeffs.at<double>(2, 0));
-  dist_coeff_p2->setDouble(new_dist_coeffs.at<double>(3, 0));
-  dist_coeff_k3->setDouble(new_dist_coeffs.at<double>(4, 0));
+  cv::Mat tmp_dist_coeffs(5, 1, CV_64F);
+  dist_coeffs.copyTo(tmp_dist_coeffs);
+  dist_coeff_k1->setDouble(tmp_dist_coeffs.at<double>(0));
+  dist_coeff_k2->setDouble(tmp_dist_coeffs.at<double>(1));
+  dist_coeff_p1->setDouble(tmp_dist_coeffs.at<double>(2));
+  dist_coeff_p2->setDouble(tmp_dist_coeffs.at<double>(3));
+  dist_coeff_k3->setDouble(tmp_dist_coeffs.at<double>(4));
 }
 
 void CameraIntrinsicParameters::reset() {

--- a/src/shared/util/camera_parameters.cpp
+++ b/src/shared/util/camera_parameters.cpp
@@ -219,6 +219,7 @@ void CameraExtrinsicParameters::addCalibrationPointSet(cv::Point2d image, cv::Po
   set->addChild(new VarDouble("image_y", image.y));
   set->addChild(new VarDouble("field_x", field.x));
   set->addChild(new VarDouble("field_y", field.y));
+  set->addChild(new VarDouble("field_z", field.z));
   calibrationPoints->addChild(set);
 }
 
@@ -247,7 +248,8 @@ std::vector<cv::Point3d> CameraExtrinsicParameters::getCalibFieldPoints() {
   for (auto& pointSet : calibrationPoints->getChildren()) {
     auto field_x = (VarDouble*)pointSet->findChild("field_x");
     auto field_y = (VarDouble*)pointSet->findChild("field_y");
-    points.emplace_back(field_x->getDouble(), field_y->getDouble(), 0);
+    auto field_z = (VarDouble*)pointSet->findChild("field_z");
+    points.emplace_back(field_x->getDouble(), field_y->getDouble(), field_z->getDouble());
   }
   return points;
 }

--- a/src/shared/util/camera_parameters.cpp
+++ b/src/shared/util/camera_parameters.cpp
@@ -118,12 +118,30 @@ CameraExtrinsicParameters::CameraExtrinsicParameters() {
   tvec_y = new VarDouble("tvec y", 0.0);
   tvec_z = new VarDouble("tvec z", 0.0);
 
+  fixFocalLength = new VarBool("Fix focal length", false);
+  fixPrinciplePoint = new VarBool("Fix principle point", false);
+  fixTangentialDistortion = new VarBool("Fix tangential distortion", true);
+  fixK1 = new VarBool("Fix k1", false);
+  fixK2 = new VarBool("Fix k2", false);
+  fixK3 = new VarBool("Fix k3", false);
+
+  calibrationPoints = new VarList("Calibration points");
+  auto addPoint = new VarTrigger("Calibration point", "Add");
+
   settings->addChild(rvec_x);
   settings->addChild(rvec_y);
   settings->addChild(rvec_z);
   settings->addChild(tvec_x);
   settings->addChild(tvec_y);
   settings->addChild(tvec_z);
+  settings->addChild(fixFocalLength);
+  settings->addChild(fixPrinciplePoint);
+  settings->addChild(fixTangentialDistortion);
+  settings->addChild(fixK1);
+  settings->addChild(fixK2);
+  settings->addChild(fixK3);
+  settings->addChild(addPoint);
+  settings->addChild(calibrationPoints);
 
   connect(rvec_x, SIGNAL(hasChanged(VarType*)), this, SLOT(updateRVec()));
   connect(rvec_y, SIGNAL(hasChanged(VarType*)), this, SLOT(updateRVec()));
@@ -131,6 +149,7 @@ CameraExtrinsicParameters::CameraExtrinsicParameters() {
   connect(tvec_x, SIGNAL(hasChanged(VarType*)), this, SLOT(updateTVec()));
   connect(tvec_y, SIGNAL(hasChanged(VarType*)), this, SLOT(updateTVec()));
   connect(tvec_z, SIGNAL(hasChanged(VarType*)), this, SLOT(updateTVec()));
+  connect(addPoint, SIGNAL(wasEdited(VarType*)), this, SLOT(addNewCalibrationPointSet()));
 
   rvec = cv::Mat(3, 1, CV_64FC1, cv::Scalar(0));
   tvec = cv::Mat(3, 1, CV_64FC1, cv::Scalar(0));
@@ -139,12 +158,7 @@ CameraExtrinsicParameters::CameraExtrinsicParameters() {
 }
 
 CameraExtrinsicParameters::~CameraExtrinsicParameters() {
-  delete rvec_x;
-  delete rvec_y;
-  delete rvec_z;
-  delete tvec_x;
-  delete tvec_y;
-  delete tvec_z;
+  settings->deleteAllChildren();
   delete settings;
 }
 
@@ -189,4 +203,63 @@ void CameraExtrinsicParameters::reset() {
   rvec_y->resetToDefault();
   rvec_z->resetToDefault();
   updateRVec();
+
+  clearCalibrationPoints();
+}
+
+void CameraExtrinsicParameters::addNewCalibrationPointSet() {
+  cv::Point2d image(50, 50);
+  cv::Point3d field(0, 0, 0);
+  addCalibrationPointSet(image, field);
+}
+
+void CameraExtrinsicParameters::addCalibrationPointSet(cv::Point2d image, cv::Point3d field) {
+  auto set = new VarList("point");
+  set->addChild(new VarDouble("image_x", image.x));
+  set->addChild(new VarDouble("image_y", image.y));
+  set->addChild(new VarDouble("field_x", field.x));
+  set->addChild(new VarDouble("field_y", field.y));
+  calibrationPoints->addChild(set);
+}
+
+void CameraExtrinsicParameters::clearCalibrationPoints() {
+  settings->removeChild(calibrationPoints);
+  // Note: The old points should be deleted, but deleting them here causes a seg fault due to some
+  // update handlers that are called on the var types afterwards...
+  // So for now, they are not deleted at all
+//  calibrationPoints->deleteAllChildren();
+  calibrationPoints = new VarList("Calibration points");
+  settings->addChild(calibrationPoints);
+}
+
+std::vector<cv::Point2d> CameraExtrinsicParameters::getCalibImagePoints() {
+  std::vector<cv::Point2d> points;
+  for (auto& pointSet : calibrationPoints->getChildren()) {
+    auto image_x = (VarDouble*)pointSet->findChild("image_x");
+    auto image_y = (VarDouble*)pointSet->findChild("image_y");
+    points.emplace_back(image_x->getDouble(), image_y->getDouble());
+  }
+  return points;
+}
+
+std::vector<cv::Point3d> CameraExtrinsicParameters::getCalibFieldPoints() {
+  std::vector<cv::Point3d> points;
+  for (auto& pointSet : calibrationPoints->getChildren()) {
+    auto field_x = (VarDouble*)pointSet->findChild("field_x");
+    auto field_y = (VarDouble*)pointSet->findChild("field_y");
+    points.emplace_back(field_x->getDouble(), field_y->getDouble(), 0);
+  }
+  return points;
+}
+
+int CameraExtrinsicParameters::getCalibrationPointSize() {
+  return calibrationPoints->getChildrenCount();
+}
+
+VarDouble* CameraExtrinsicParameters::getCalibImageValueX(int index) {
+  return (VarDouble*)calibrationPoints->getChildren()[index]->findChild("image_x");
+}
+
+VarDouble* CameraExtrinsicParameters::getCalibImageValueY(int index) {
+  return (VarDouble*)calibrationPoints->getChildren()[index]->findChild("image_y");
 }

--- a/src/shared/util/camera_parameters.h
+++ b/src/shared/util/camera_parameters.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <VarTypes.h>
+
+#include <QObject>
+#include <opencv2/opencv.hpp>
+
+using namespace VarTypes;
+
+class CameraIntrinsicParameters : public QObject {
+  Q_OBJECT
+
+ public:
+  CameraIntrinsicParameters();
+  ~CameraIntrinsicParameters() override;
+
+  void updateConfigValues() const;
+  void reset();
+
+  VarList *settings;
+
+  cv::Mat camera_mat;
+  cv::Mat dist_coeffs;
+
+  // derived matrices for faster computation
+  cv::Mat camera_mat_inv;
+
+  VarDouble *focal_length_x;
+  VarDouble *focal_length_y;
+  VarDouble *principal_point_x;
+  VarDouble *principal_point_y;
+
+  VarDouble *dist_coeff_k1;
+  VarDouble *dist_coeff_k2;
+  VarDouble *dist_coeff_p1;
+  VarDouble *dist_coeff_p2;
+  VarDouble *dist_coeff_k3;
+ public slots:
+  void updateCameraMat();
+  void updateDistCoeffs();
+};
+
+class CameraExtrinsicParameters : public QObject {
+  Q_OBJECT
+
+ private:
+  VarDouble *rvec_x;
+  VarDouble *rvec_y;
+  VarDouble *rvec_z;
+
+  VarDouble *tvec_x;
+  VarDouble *tvec_y;
+  VarDouble *tvec_z;
+
+ public:
+  CameraExtrinsicParameters();
+  ~CameraExtrinsicParameters() override;
+
+  void updateConfigValues();
+  void reset();
+
+  VarList *settings;
+
+  cv::Mat rvec;
+  cv::Mat tvec;
+
+  // derived matrices for faster computation
+  cv::Mat rotation_mat_inv;
+  cv::Mat right_side_mat;
+
+ public slots:
+  void updateRVec();
+  void updateTVec();
+};

--- a/src/shared/util/camera_parameters.h
+++ b/src/shared/util/camera_parameters.h
@@ -52,6 +52,8 @@ class CameraExtrinsicParameters : public QObject {
   VarDouble *tvec_y;
   VarDouble *tvec_z;
 
+  VarList* calibrationPoints;
+
  public:
   CameraExtrinsicParameters();
   ~CameraExtrinsicParameters() override;
@@ -61,6 +63,13 @@ class CameraExtrinsicParameters : public QObject {
 
   VarList *settings;
 
+  VarBool *fixFocalLength;
+  VarBool *fixPrinciplePoint;
+  VarBool *fixTangentialDistortion;
+  VarBool *fixK1;
+  VarBool *fixK2;
+  VarBool *fixK3;
+
   cv::Mat rvec;
   cv::Mat tvec;
 
@@ -68,10 +77,16 @@ class CameraExtrinsicParameters : public QObject {
   cv::Mat rotation_mat_inv;
   cv::Mat right_side_mat;
 
-  std::vector<cv::Point3d> calib_field_points;
-  std::vector<cv::Point2d> calib_image_points;
+  void addCalibrationPointSet(cv::Point2d image, cv::Point3d field);
+  void clearCalibrationPoints();
+  vector<cv::Point2d> getCalibImagePoints();
+  vector<cv::Point3d> getCalibFieldPoints();
+  int getCalibrationPointSize();
+  VarDouble* getCalibImageValueX(int index);
+  VarDouble* getCalibImageValueY(int index);
 
  public slots:
   void updateRVec();
   void updateTVec();
+  void addNewCalibrationPointSet();
 };

--- a/src/shared/util/camera_parameters.h
+++ b/src/shared/util/camera_parameters.h
@@ -68,6 +68,9 @@ class CameraExtrinsicParameters : public QObject {
   cv::Mat rotation_mat_inv;
   cv::Mat right_side_mat;
 
+  std::vector<cv::Point3d> calib_field_points;
+  std::vector<cv::Point2d> calib_image_points;
+
  public slots:
   void updateRVec();
   void updateTVec();

--- a/src/shared/util/conversions_greyscale.cpp
+++ b/src/shared/util/conversions_greyscale.cpp
@@ -1,0 +1,74 @@
+#include "conversions_greyscale.h"
+
+void ConversionsGreyscale::cvColor2Grey(const RawImage &src, Image<raw8> *dst) {
+  // Allocate image if not already allocated. Allocate method will do
+  // nothing if data already allocated for correct width/height.
+  dst->allocate(src.getWidth(), src.getHeight());
+
+  switch (src.getColorFormat()) {
+    case COLOR_RGB8:
+      cvColor2Grey(src, CV_8UC3, dst, cv::COLOR_RGB2GRAY);
+      break;
+    case COLOR_RGBA8:
+      cvColor2Grey(src, CV_8UC4, dst, cv::COLOR_RGBA2GRAY);
+      break;
+    case COLOR_YUV422_UYVY:
+      cvColor2Grey(src, CV_8UC2, dst, cv::COLOR_YUV2GRAY_UYVY);
+      break;
+    case COLOR_YUV422_YUYV:
+      cvColor2Grey(src, CV_8UC2, dst, cv::COLOR_YUV2GRAY_YUYV);
+      break;
+    case COLOR_RGB16:
+      cvColor2Grey(src, CV_16UC3, dst, cv::COLOR_RGB2GRAY);
+      break;
+    case COLOR_RAW16:
+      [[fallthrough]];
+    case COLOR_MONO16:
+      cv16bit2_8bit(src, dst);
+      break;
+    case COLOR_MONO8:
+      [[fallthrough]];
+    case COLOR_RAW8:
+      // already in the correct format
+      copyData(src, dst);
+      break;
+    case COLOR_YUV411:
+      [[fallthrough]];
+    case COLOR_YUV444:
+      [[fallthrough]];
+    default:
+      manualColor2Grey(src, dst);
+      break;
+  }
+}
+
+void ConversionsGreyscale::cvColor2Grey(const RawImage &src, const int src_data_format, Image<raw8> *dst,
+                                        const cv::ColorConversionCodes conversion_code) {
+  cv::Mat srcMat(src.getWidth(), src.getHeight(), src_data_format, src.getData());
+  cv::Mat dstMat(dst->getWidth(), dst->getHeight(), CV_8UC1, dst->getData());
+  cv::cvtColor(srcMat, dstMat, conversion_code);
+}
+
+void ConversionsGreyscale::cv16bit2_8bit(const RawImage &src, Image<raw8> *dst) {
+  cv::Mat srcMat(src.getWidth(), src.getHeight(), CV_16UC1, src.getData());
+  cv::Mat dstMat(dst->getWidth(), dst->getHeight(), CV_8UC1, dst->getData());
+  // convertTo drops higher bits. Need to rescale 16 bit values to
+  // 8bit range. Should have a scale factor of 1/256. See
+  // https://stackoverflow.com/a/10420743
+  srcMat.convertTo(dstMat, CV_8U, 0.00390625);
+}
+
+void ConversionsGreyscale::manualColor2Grey(const RawImage &src, Image<raw8> *dst) {
+  for (int i = 0; i < src.getWidth(); ++i) {
+    for (int j = 0; j < src.getHeight(); ++j) {
+      const auto pixel = src.getRgb(i, j);
+      *(dst->getPixelPointer(i, j)) = (pixel.r + pixel.g + pixel.b) / 3;
+    }
+  }
+}
+
+void ConversionsGreyscale::copyData(const RawImage &src, Image<raw8> *dst) {
+  cv::Mat srcMat(src.getWidth(), src.getHeight(), CV_8UC1, src.getData());
+  cv::Mat dstMat(dst->getWidth(), dst->getHeight(), CV_8UC1, dst->getData());
+  srcMat.copyTo(dstMat);
+}

--- a/src/shared/util/conversions_greyscale.h
+++ b/src/shared/util/conversions_greyscale.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <image.h>
+
+#include <opencv2/opencv.hpp>
+
+#include "colors.h"
+#include "rawimage.h"
+#include "util.h"
+
+class ConversionsGreyscale {
+ public:
+  static void cvColor2Grey(const RawImage& src, Image<raw8>* dst);
+  static void cvColor2Grey(const RawImage& src, int src_data_format, Image<raw8>* dst,
+                           cv::ColorConversionCodes conversion_code);
+  static void cv16bit2_8bit(const RawImage& src, Image<raw8>* dst);
+  static void manualColor2Grey(const RawImage& src, Image<raw8>* dst);
+  static void copyData(const RawImage& src, Image<raw8>* dst);
+};

--- a/src/shared/util/field.cpp
+++ b/src/shared/util/field.cpp
@@ -427,7 +427,10 @@ RoboCupField::RoboCupField() {
   shapeTypeMap["RightFieldLeftPenaltyStretch"] = RightFieldLeftPenaltyStretch;
   shapeTypeMap["RightFieldRightPenaltyStretch"] = RightFieldRightPenaltyStretch;
 
-  updateFieldLinesAndArcs();
+  if (field_lines.empty() && field_arcs.empty()) {
+    // Generate default field lines and arcs
+    updateFieldLinesAndArcs();
+  }
 
   emit calibrationChanged();
 }

--- a/src/shared/util/field.cpp
+++ b/src/shared/util/field.cpp
@@ -361,6 +361,8 @@ RoboCupField::RoboCupField() {
        "Total Number of Cameras", 2);
   num_cameras_local = new VarInt(
        "Local Number of Cameras", 2);
+  center_line = new VarBool(
+    "Center Line", true);
 
   updateShapes = new VarTrigger("Field Lines/Arcs","Update");
   applyDivisionA = new VarTrigger("Division A", "Apply");
@@ -390,6 +392,7 @@ RoboCupField::RoboCupField() {
   settings->addChild(max_robot_radius);
   settings->addChild(num_cameras_total);
   settings->addChild(num_cameras_local);
+  settings->addChild(center_line);
   settings->addChild(var_num_lines);
   settings->addChild(var_num_arcs);
   settings->addChild(updateShapes);
@@ -445,6 +448,7 @@ RoboCupField::~RoboCupField() {
   delete max_robot_radius;
   delete num_cameras_total;
   delete num_cameras_local;
+  delete center_line;
   delete var_num_lines;
   delete var_num_arcs;
   for (size_t i = 0; i < field_lines.size(); ++i) {
@@ -699,13 +703,17 @@ void RoboCupField::updateFieldLinesAndArcs() {
     field_lines.push_back(new FieldLine("LeftGoalLine", -fieldLengthHalf, -fieldWidthHalf, -fieldLengthHalf, fieldWidthHalf, line_thickness->getDouble()));
     field_lines.push_back(new FieldLine("RightGoalLine", fieldLengthHalf, -fieldWidthHalf, fieldLengthHalf, fieldWidthHalf, line_thickness->getDouble()));
     field_lines.push_back(new FieldLine("HalfwayLine", 0, -fieldWidthHalf, 0, fieldWidthHalf, line_thickness->getDouble()));
-    field_lines.push_back(new FieldLine("CenterLine", -fieldLengthHalf, 0, fieldLengthHalf, 0, line_thickness->getDouble()));
     field_lines.push_back(new FieldLine("LeftPenaltyStretch", -penAreaX, -penAreaY, -penAreaX, penAreaY, line_thickness->getDouble()));
     field_lines.push_back(new FieldLine("RightPenaltyStretch", penAreaX, -penAreaY, penAreaX, penAreaY, line_thickness->getDouble()));
     field_lines.push_back(new FieldLine("LeftFieldLeftPenaltyStretch", -fieldLengthHalf, -penAreaY, -penAreaX, -penAreaY, line_thickness->getDouble()));
     field_lines.push_back(new FieldLine("LeftFieldRightPenaltyStretch", -fieldLengthHalf, penAreaY, -penAreaX, penAreaY, line_thickness->getDouble()));
     field_lines.push_back(new FieldLine("RightFieldRightPenaltyStretch", fieldLengthHalf, -penAreaY, penAreaX, -penAreaY, line_thickness->getDouble()));
     field_lines.push_back(new FieldLine("RightFieldLeftPenaltyStretch", fieldLengthHalf, penAreaY, penAreaX, penAreaY, line_thickness->getDouble()));
+
+    if (center_line->getBool()) {
+      field_lines.push_back(
+        new FieldLine("CenterLine", -fieldLengthHalf, 0, fieldLengthHalf, 0, line_thickness->getDouble()));
+    }
 
     var_num_lines->setInt(field_lines.size());
     for (size_t i = 0; i < field_lines.size(); ++i) {

--- a/src/shared/util/field.h
+++ b/src/shared/util/field.h
@@ -191,6 +191,7 @@ public:
   VarDouble* max_robot_radius;
   VarInt* num_cameras_total;
   VarInt* num_cameras_local;
+  VarBool* center_line;
   VarInt* var_num_lines;
   VarInt* var_num_arcs;
   VarList* field_lines_list;

--- a/src/shared/util/geomalgo.h
+++ b/src/shared/util/geomalgo.h
@@ -47,6 +47,17 @@ num offset_to_line(const vector2d<num> x0,const vector2d<num> x1,const vector2d<
   return(n.dot(p - x0));
 }
 
+// returns closest point from point p on line x0-x1
+template <class num>
+vector2d<num> closest_point_on_line(const vector2d<num> x0,const vector2d<num> x1,const vector2d<num> p)
+{
+  vector2d<num> lineDir = x1-x0;
+  lineDir.normalize();
+  vector2d<num> v = p - x0;
+  auto d = v.dot(lineDir);
+  return x0 + lineDir * d;
+}
+
 // returns perpendicular offset from line x0-x1 to point p
 template <class num>
 num offset_along_line(const vector2d<num> x0,const vector2d<num> x1,const vector2d<num> p)
@@ -97,7 +108,7 @@ vector2d<num> intersection(const vector2d<num> a1, const vector2d<num> a2,
   vector2d<num> b2r = (b2 - a1).rotate(-a.angle());
   vector2d<num> br = (b1r - b2r);
 
-  return 
+  return
     vector2d<num>(b2r.x - b2r.y * (br.x / br.y), 0.0).rotate(a.angle()) + a1;
 }
 
@@ -364,11 +375,11 @@ double ray_plane_intersect(vector pOrigin,vector pNormal,
 
 //  return((dot(pNormal,pOrigin) - dot(pNormal,rOrigin)) /
 //         dot(pNormal,rVector));
-  
+
 //  double numer = dot(pNormal,rOrigin) - dot(pNormal,pOrigin);
 //  double denom = dot(pNormal,rVector);
 //  return(-(numer / denom));
-  
+
 }
 
 template <class vector, class real>

--- a/src/shared/util/image.h
+++ b/src/shared/util/image.h
@@ -209,6 +209,13 @@ public:
 
   void drawLine (int x0, int y0, int x1, int y1 , PIXEL val)
   {
+    if(abs((long) x0) > 50000L ||
+       abs((long) y0) > 50000L ||
+       abs((long) x1) > 50000L ||
+       abs((long) y1) > 50000L) {
+      // sanity check to avoid endless or very long loops
+      return;
+    }
 
   int x, y, dx, dy, sx, sy, ax, ay, decy, decx;
   x = x0;
@@ -263,6 +270,13 @@ public:
 
 void drawFatLine (int x0, int y0, int x1, int y1 , PIXEL val)
 {
+  if(abs((long) x0) > 50000L ||
+     abs((long) y0) > 50000L ||
+     abs((long) x1) > 50000L ||
+     abs((long) y1) > 50000L) {
+    // sanity check to avoid endless or very long loops
+    return;
+  }
 
   int x, y, dx, dy, sx, sy, ax, ay, decy, decx;
   x = x0;


### PR DESCRIPTION
Based on the work of @rhololkeolke I've implemented the openCV chessboard calibration with intrinsic and extrinsic models.

So far, a calibration of the intrinsics with a chessboard can be done through a new widget. I've tested it with the original SSL FLIR cameras and a DIN A4 7x9 chessboard. The RMS error is shown and the result is saved.
Additionally, there is a button to calibrate the extrinsics based on the four field corner markers.

If enabled in the config tree (Camera Calibrator), the model is used for field2Image and image2Field, but the code is not yet optimized, especially the image2field where several matrix inversions are done.

The UI widget also still needs more structure.

I'll continue work on this, but if anyone wants to start testing this branch, you are welcome.