### PR TITLE
Remove vertical splitter which has no lower content

### DIFF
--- a/src/app/gui/mainwindow.cpp
+++ b/src/app/gui/mainwindow.cpp
@@ -57,7 +57,6 @@ MainWindow::MainWindow(bool start_capture, bool enforce_affinity, int num_camera
   stackvar->addChild(multi_stack->getSettings());
   //create tabs, GL visualizations and tool-panes for each capture thread in the multi-stack:
   for (unsigned int i=0;i<multi_stack->threads.size();i++) {
-    QSplitter * splitter2 = new QSplitter(Qt::Vertical);
     VisionStack * s = multi_stack->threads[i]->getStack();
     if (affinity!=0) multi_stack->threads[i]->setAffinityManager(affinity);
 
@@ -108,9 +107,6 @@ MainWindow::MainWindow(bool start_capture, bool enforce_affinity, int num_camera
             }
             right_tab->addTab(tmp_control,QString::fromStdString(p->getName()));
           }
-
-          QWidget * tmp_vis = p->getVisualizationWidget();
-          if (tmp_vis!=0) splitter2->addWidget(tmp_vis);
         }
 
       } else {
@@ -126,9 +122,7 @@ MainWindow::MainWindow(bool start_capture, bool enforce_affinity, int num_camera
     }
     stackvar->addChild(threadvar);
 
-    splitter2->addWidget(stack_widget);
-    splitter2->addWidget(new QWidget());
-    cam_tabs->addTab(splitter2, label);
+    cam_tabs->addTab(stack_widget, label);
   }
 
   if (affinity!=0) affinity->demandCore(multi_stack->threads.size());


### PR DESCRIPTION
In the past, there where only two cameras and they
were arranged above each other.
Now we have tabs for each camera/thread and the
lower part is just empty and wastes space.
This commit removes this empty space such that
the camera image and the control widgets expand
to the bottom.

It looks like this now:

![image](https://user-images.githubusercontent.com/779094/72555055-267cfb00-389c-11ea-884e-fe5b1ab09f01.png)