### PR TITLE
Initialize mask with ones to detect bot pattern images correctly

### DIFF
--- a/src/shared/cmvision/cmvision_region.cpp
+++ b/src/shared/cmvision/cmvision_region.cpp
@@ -408,6 +408,7 @@ void ImageProcessor::processYUV422_UYVY(const RawImage * image, int min_blob_are
   img_thresholded->allocate(image->getWidth(),image->getHeight());
   Image<raw8> mask;
   mask.allocate(image->getWidth(),image->getHeight());
+  memset(mask.getData(),-1,mask.getNumBytes());
   CMVisionThreshold::thresholdImageYUV422_UYVY(img_thresholded,image,lut,&mask);
   processThresholded(img_thresholded,min_blob_area);
 }
@@ -416,6 +417,7 @@ void ImageProcessor::processYUV444(const ImageInterface * image, int min_blob_ar
   img_thresholded->allocate(image->getWidth(),image->getHeight());
   Image<raw8> mask;
   mask.allocate(image->getWidth(),image->getHeight());
+  memset(mask.getData(),-1,mask.getNumBytes());
   CMVisionThreshold::thresholdImageYUV444(img_thresholded,image,lut,&mask);
   processThresholded(img_thresholded,min_blob_area);
 }


### PR DESCRIPTION
With #158 a image mask has been introduced for thresholding.

The thresholding is also used to extract the blobs from the standard robot pattern (which is an image), in which case a default mask is generated.

Unfortunately, the mask is generated all zero, instead of all one, so the standard robot pattern can not be read correctly.

This PR initializes the mask with ones instead. This fixed the issue for me.