### PR TITLE
Use QT5 instead of QT4 by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,8 @@ jobs:
       - run: apt-get update -qq && apt-get install -qq git
       - checkout
       - run: DEBIAN_FRONTEND=noninteractive ./InstallPackagesUbuntu.sh
-      - run: mkdir -p build && cd build && cmake -DUSE_V4L=true .. && cd ..
+      - run: mkdir -p build
+      - run: cmake -B build -DUSE_V4L=true .
       - run: make
   build-splitter:
     docker:
@@ -24,18 +25,18 @@ jobs:
       - run: apt-get update -qq && apt-get install -qq git
       - checkout
       - run: DEBIAN_FRONTEND=noninteractive ./InstallPackagesUbuntu.sh
-      - run: mkdir -p build && cd build && cmake -DUSE_SPLITTER=true .. && cd ..
+      - run: mkdir -p build
       - run: cmake -B build -DUSE_SPLITTER=true .
       - run: make
-  build-qt5:
+  build-qt4:
     docker:
       - image: ubuntu:18.04
     steps:
       - run: apt-get update -qq && apt-get install -qq git
       - checkout
       - run: DEBIAN_FRONTEND=noninteractive ./InstallPackagesUbuntu.sh
-      - run: apt-get install -qq qtdeclarative5-dev
-      - run: mkdir -p build && cd build && cmake -DUSE_QT5=true .. && cd ..
+      - run: apt-get install -qq libqt4-dev
+      - run: mkdir -p build
       - run: cmake -B build -DUSE_QT5=true .
       - run: make
 
@@ -46,4 +47,4 @@ workflows:
       - build
       - build-v4l
       - build-splitter
-      - build-qt5
+      - build-qt4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(ssl-vision)
 set(OpenGL_GL_PREFERENCE LEGACY)
-set(USE_QT5 FALSE CACHE BOOL "Use Qt5 instead of Qt4")
+set(USE_QT5 TRUE CACHE BOOL "Use Qt5 instead of Qt4")
 set(USE_DC1394 TRUE CACHE BOOL "Compile with DC1394 driver (firewire cameras)")
 set(USE_SPINNAKER FALSE CACHE BOOL "Compile with Spinnaker driver (FLIR cameras)")
 set(USE_mvIMPACT FALSE CACHE BOOL "Compile with mvImpact driver (bluefox USB2 + USB3 cameras)")

--- a/InstallPackagesArch.sh
+++ b/InstallPackagesArch.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # These are the packages required for install on Arch Linux systems.
-sudo pacman -Sy gcc qt4 eigen protobuf libdc1394 cmake v4l-utils jsoncpp
+sudo pacman -Sy gcc qt5-base eigen protobuf libdc1394 cmake v4l-utils jsoncpp

--- a/InstallPackagesUbuntu.sh
+++ b/InstallPackagesUbuntu.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # These are the packages required on Ubuntu systems.
-apt-get install -qq g++ libqt4-dev libeigen3-dev protobuf-compiler libprotobuf-dev libdc1394-22 libdc1394-22-dev cmake libv4l-0 libopencv-dev freeglut3-dev
+apt-get install -qq g++ qtdeclarative5-dev libeigen3-dev protobuf-compiler libprotobuf-dev libdc1394-22 libdc1394-22-dev cmake libv4l-0 libopencv-dev freeglut3-dev


### PR DESCRIPTION
QT5 is available on Ubuntu 16.04 LTS and 18.04 LTS now, so it should be save to default to QT5 by default.

#163 is actually not compatible to QT4 anymore, probably because of the new OpenCV calib3d dependency. Instead of putting effort into analyzing the root cause for this, I suggest to drop support for QT4 completely. 

Is there any reason to keep the possibility of running with QT4? Otherwise, I will remove the `USE_QT5` option completely in this PR as well.