### PR TITLE
Feature/image size

### DIFF
--- a/src/app/plugins/plugin_cameracalib.cpp
+++ b/src/app/plugins/plugin_cameracalib.cpp
@@ -104,6 +104,11 @@ ProcessResult PluginCameraCalibration::process(
     FrameData* data, RenderOptions* options) {
   video_width=data->video.getWidth();
   video_height=data->video.getHeight();
+  if(camera_parameters.additional_calibration_information->imageWidth->getInt() != video_width ||
+     camera_parameters.additional_calibration_information->imageHeight->getInt() != video_height){
+      camera_parameters.additional_calibration_information->imageWidth->setInt(video_width);
+      camera_parameters.additional_calibration_information->imageHeight->setInt(video_height);
+  }
   (void)options;
   if(ccw) {
     if(ccw->getDetectEdges()) {

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -138,8 +138,8 @@ int main(int argc, char *argv[])
                     printf("  -tx=%.2f\n",calib.tx());
                     printf("  -ty=%.2f\n",calib.ty());
                     printf("  -tz=%.2f\n",calib.tz());
-                    printf( " -pixel_image_width=%d\n",calib.pixel_image_width());
-                    printf(" -pixel_image_height=%d\n",calib.pixel_image_height());
+                    printf("  -pixel_image_width=%u\n",calib.pixel_image_width());
+                    printf("  -pixel_image_height=%u\n",calib.pixel_image_height());
 
                     if (calib.has_derived_camera_world_tx() && calib.has_derived_camera_world_ty() && calib.has_derived_camera_world_tz()) {
                       printf("  -derived_camera_world_tx=%.f\n",calib.derived_camera_world_tx());

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -138,6 +138,8 @@ int main(int argc, char *argv[])
                     printf("  -tx=%.2f\n",calib.tx());
                     printf("  -ty=%.2f\n",calib.ty());
                     printf("  -tz=%.2f\n",calib.tz());
+                    printf( " -pixel_image_width=%d\n",calib.pixel_image_width());
+                    printf(" -pixel_image_height=%d\n",calib.pixel_image_height());
 
                     if (calib.has_derived_camera_world_tx() && calib.has_derived_camera_world_ty() && calib.has_derived_camera_world_tz()) {
                       printf("  -derived_camera_world_tx=%.f\n",calib.derived_camera_world_tx());

--- a/src/shared/proto/messages_robocup_ssl_geometry.proto
+++ b/src/shared/proto/messages_robocup_ssl_geometry.proto
@@ -69,6 +69,8 @@ message SSL_GeometryCameraCalibration {
   optional float derived_camera_world_tx = 13;
   optional float derived_camera_world_ty = 14;
   optional float derived_camera_world_tz = 15;
+  optional uint32 pixel_image_width = 16;
+  optional uint32 pixel_image_height = 17;
 }
 
 message SSL_GeometryData {

--- a/src/shared/util/camera_calibration.cpp
+++ b/src/shared/util/camera_calibration.cpp
@@ -78,8 +78,8 @@ void CameraParameters::toProtoBuffer(SSL_GeometryCameraCalibration &buffer) cons
   buffer.set_derived_camera_world_ty(v_out.y);
   buffer.set_derived_camera_world_tz(v_out.z);
 
-  buffer.set_pixel_image_width(imageWidth->getInt());
-  buffer.set_pixel_image_height(imageHeight->getInt());
+  buffer.set_pixel_image_width(additional_calibration_information->imageWidth->getInt());
+  buffer.set_pixel_image_height(additional_calibration_information->imageHeight->getInt());
 
 }
 
@@ -105,8 +105,7 @@ void CameraParameters::addSettingsToList(VarList& list) {
   list.addChild(tx);
   list.addChild(ty);
   list.addChild(tz);
-  list.addChild(imageWidth);
-  list.addChild(imageHeight);
+
 }
 
 double CameraParameters::radialDistortion(double ru) const {

--- a/src/shared/util/camera_calibration.cpp
+++ b/src/shared/util/camera_calibration.cpp
@@ -105,7 +105,6 @@ void CameraParameters::addSettingsToList(VarList& list) {
   list.addChild(tx);
   list.addChild(ty);
   list.addChild(tz);
-
 }
 
 double CameraParameters::radialDistortion(double ru) const {

--- a/src/shared/util/camera_calibration.cpp
+++ b/src/shared/util/camera_calibration.cpp
@@ -78,6 +78,9 @@ void CameraParameters::toProtoBuffer(SSL_GeometryCameraCalibration &buffer) cons
   buffer.set_derived_camera_world_ty(v_out.y);
   buffer.set_derived_camera_world_tz(v_out.z);
 
+  buffer.set_pixel_image_width(imageWidth->getInt());
+  buffer.set_pixel_image_height(imageHeight->getInt());
+
 }
 
 GVector::vector3d< double > CameraParameters::getWorldLocation() {
@@ -102,6 +105,8 @@ void CameraParameters::addSettingsToList(VarList& list) {
   list.addChild(tx);
   list.addChild(ty);
   list.addChild(tz);
+  list.addChild(imageWidth);
+  list.addChild(imageHeight);
 }
 
 double CameraParameters::radialDistortion(double ru) const {
@@ -754,6 +759,11 @@ CameraParameters::AdditionalCalibrationInformation::
   cov_ls_x = new VarDouble("Cov line segment measurement x", 1.0);
   cov_ls_y = new VarDouble("Cov line segment measurement y", 1.0);
   pointSeparation = new VarDouble("Points separation", 150);
+
+  imageWidth = new VarInt("Image width",0,0);
+  imageWidth->addFlags(VARTYPE_FLAG_NOLOAD_ATTRIBUTES);
+  imageHeight = new VarInt("Image height",0,0);
+  imageHeight->addFlags(VARTYPE_FLAG_NOLOAD_ATTRIBUTES);
 }
 
 void CameraParameters::AdditionalCalibrationInformation::updateControlPoints() {
@@ -841,6 +851,8 @@ CameraParameters::AdditionalCalibrationInformation::~AdditionalCalibrationInform
   delete cov_ls_x;
   delete cov_ls_y;
   delete pointSeparation;
+  delete imageWidth;
+  delete imageHeight;
 }
 
 void CameraParameters::AdditionalCalibrationInformation::addSettingsToList(
@@ -860,4 +872,6 @@ void CameraParameters::AdditionalCalibrationInformation::addSettingsToList(
   list.addChild(cov_ls_x);
   list.addChild(cov_ls_y);
   list.addChild(pointSeparation);
+  list.addChild(imageWidth);
+  list.addChild(imageHeight);
 }

--- a/src/shared/util/camera_calibration.h
+++ b/src/shared/util/camera_calibration.h
@@ -153,6 +153,8 @@ public:
 
       VarDouble* pointSeparation;
 
+      VarInt* imageWidth;
+      VarInt* imageHeight;
   private:
       RoboCupField* field;
       std::vector<GVector::vector2d<double> >


### PR DESCRIPTION
Adds the image sizes to the geometryCalibrationData of each camera, allowing to better reconstruct if objects should be visible or not.
fixes #175  