### PR TITLE
Fix/basler oscillating timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Then build with the corresponding option:
  * `-DUSE_FLYCAP=true`
  * `-DUSE_V4L=true`
  
-Example: `cd build; cmake -DUSE_SPINNAKER=true ..`. As these are cached cmake option, you only need to run this once and can build with `make` afterwards.
+Example for a release build: `cd build; cmake -DUSE_SPINNAKER=true -DCMAKE_BUILD_TYPE=Release ..`.
+ As these are cached cmake options, you only need to run this once and can build with `make` afterwards.
 
 ### Virtual Splitter cameras
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then build with the corresponding option:
  * `-DUSE_FLYCAP=true`
  * `-DUSE_V4L=true`
  
-Example for a release build: `cd build; cmake -DUSE_SPINNAKER=true -DCMAKE_BUILD_TYPE=Release ..`.
+Example for a release build: `cd build; cmake -DUSE_SPINNAKER=true ..`.
  As these are cached cmake options, you only need to run this once and can build with `make` afterwards.
 
 ### Virtual Splitter cameras

--- a/src/shared/capture/capture_basler.cpp
+++ b/src/shared/capture/capture_basler.cpp
@@ -96,31 +96,31 @@ bool CaptureBasler::_buildCamera() {
 	Pylon::DeviceInfoList devices;
 	int amt = Pylon::CTlFactory::GetInstance().EnumerateDevices(devices);
 	current_id = v_camera_id->get();
-    printf("Current camera id: %d\n", current_id);
+	printf("Current camera id: %d\n", current_id);
 	if (amt > current_id) {
 		Pylon::CDeviceInfo info = devices[current_id];
 
 		camera = new Pylon::CBaslerGigEInstantCamera(
 				Pylon::CTlFactory::GetInstance().CreateDevice(info));
-        printf("Opening camera %d...\n", current_id);
+        	printf("Opening camera %d...\n", current_id);
 		camera->Open();
-        camera->GammaSelector.SetValue(Basler_GigECamera::GammaSelector_User); //Necessary for interface to work
-        camera->AcquisitionFrameRateEnable.SetValue(true); //Turn on capped framerates
-        camera_frequency = camera->GevTimestampTickFrequency.GetValue();;
+        	camera->GammaSelector.SetValue(Basler_GigECamera::GammaSelector_User); //Necessary for interface to work
+        	camera->AcquisitionFrameRateEnable.SetValue(true); //Turn on capped framerates
+        	camera_frequency = camera->GevTimestampTickFrequency.GetValue();;
 
-        //let camera send timestamps and FrameCounts.
-	if (GenApi::IsWritable(camera->ChunkModeActive)) {
-		camera->ChunkModeActive.SetValue(true);
-		camera->ChunkSelector.SetValue(Basler_GigECamera::ChunkSelector_Timestamp);
-		camera->ChunkEnable.SetValue(true);
-		camera->ChunkSelector.SetValue(Basler_GigECamera::ChunkSelector_Framecounter);
-		camera->ChunkEnable.SetValue(true);
-		camera->GevTimestampControlReset.Execute(); //Reset the internal time stamp counter of the camera to 0
-	} else {
-		std::cout << "Failed, camera model does not support accurate timings!" << std::endl;
-		return false; //Camera does not support accurate timings
-	}
-        printf("Done!\n");
+        	//let camera send timestamps and FrameCounts.
+		if (GenApi::IsWritable(camera->ChunkModeActive)) {
+			camera->ChunkModeActive.SetValue(true);
+			camera->ChunkSelector.SetValue(Basler_GigECamera::ChunkSelector_Timestamp);
+			camera->ChunkEnable.SetValue(true);
+			camera->ChunkSelector.SetValue(Basler_GigECamera::ChunkSelector_Framecounter);
+			camera->ChunkEnable.SetValue(true);
+			camera->GevTimestampControlReset.Execute(); //Reset the internal time stamp counter of the camera to 0
+		} else {
+			std::cout << "Failed, camera model does not support accurate timings!" << std::endl;
+			return false; //Camera does not support accurate timings
+		}
+        	printf("Done!\n");
 		is_capturing = true;
 		return true;
 	}
@@ -258,7 +258,7 @@ RawImage CaptureBasler::getFrame() {
 		    double baslerTime = period* (double) timeStamp;
 		    addOffset(computerTime-baslerTime);
 		    img.setTime(getAverageOffset()+baslerTime);
-        }else{
+		}else{
 		    img.setTime(computerTime);
 		}
 

--- a/src/shared/capture/capture_basler.cpp
+++ b/src/shared/capture/capture_basler.cpp
@@ -109,6 +109,7 @@ bool CaptureBasler::_buildCamera() {
             camera->ChunkEnable.SetValue(true);
             camera->ChunkSelector.SetValue(Basler_GigECamera::ChunkSelector_Framecounter);
             camera->ChunkEnable.SetValue(true);
+            camera->GevTimestampControlReset.Execute(); //Reset the internal time stamp counter of the camera to 0
         }else{
 		    return false; //Camera does not support accurate timings
 		}
@@ -251,6 +252,7 @@ RawImage CaptureBasler::getFrame() {
 		    std::cout<<"Old Image Timestamp: "<<img.getTime()<<std::endl;
             std::cout<<"Basler diff: "<<grab_result->ChunkTimestamp.GetValue()-lastBaslerCaptureTime<<std::endl;
             std::cout<<"Image diff: "<<img.getTime()-lastCaptureTime<<std::endl;
+            std::cout<< camera->GevTimestampTickFrequency.GetValue()<<std::endl;
             lastCaptureTime = img.getTime();
             lastBaslerCaptureTime = grab_result->ChunkTimestamp.GetValue();
         }else{
@@ -363,6 +365,7 @@ void CaptureBasler::writeParameterValues(VarList* vars) {
 
         if (camera != NULL) {
             camera->Open();
+
 
             camera->BalanceRatioSelector.SetValue(
                     Basler_GigECamera::BalanceRatioSelector_Red);

--- a/src/shared/capture/capture_basler.cpp
+++ b/src/shared/capture/capture_basler.cpp
@@ -10,8 +10,8 @@
 #include <vector>
 #include <string>
 
-#define MUTEX_LOCK mutex.lock()
-#define MUTEX_UNLOCK mutex.unlock()
+#define MUTEX_LOCK std::cout<<"lock mutex"<<std::endl; mutex.lock()
+#define MUTEX_UNLOCK std::cout<<"unlock mutex"<<std::endl; mutex.unlock()
 
 int BaslerInitManager::count = 0;
 
@@ -133,6 +133,7 @@ bool CaptureBasler::startCapture() {
 		if (camera == NULL) {
 			if (!_buildCamera()) {
                 // Did not make a camera!
+                MUTEX_UNLOCK;
                 return false;
             }
 		}
@@ -361,6 +362,7 @@ void CaptureBasler::writeParameterValues(VarList* vars) {
 	//if (restart) {
 	//	_stopCapture();
 	//}
+
 	MUTEX_LOCK;
 	try {
 		if(current_id != v_camera_id->get()){

--- a/src/shared/capture/capture_basler.cpp
+++ b/src/shared/capture/capture_basler.cpp
@@ -102,7 +102,8 @@ bool CaptureBasler::_buildCamera() {
         printf("Opening camera %d...\n", current_id);
 		camera->Open();
         printf("Setting interpacket delay...\n");
-		camera->GevSCPD.SetValue(0); //TODO: check effect of changing this: Doesn't seem to matter much
+		camera->GevSCPD.SetValue(0); //TODO: check effect of changing this: higher values lower framerate slightly. 0 seems fine, actually.
+		//Might want to leave this to the Pylon API? has not been tested when there's multiple camera's.
 		if(GenApi::IsWritable(camera->ChunkModeActive)){
             camera->ChunkModeActive.SetValue(true);
             camera->ChunkSelector.SetValue(Basler_GigECamera::ChunkSelector_Timestamp);

--- a/src/shared/capture/capture_basler.cpp
+++ b/src/shared/capture/capture_basler.cpp
@@ -248,7 +248,12 @@ RawImage CaptureBasler::getFrame() {
 		}
 		if(GenApi::IsReadable(grab_result->ChunkTimestamp)){
 		    std::cout<<"Basler timestamp: "<<grab_result->ChunkTimestamp.GetValue()<<std::endl;
-		}else{
+		    std::cout<<"Old Image Timestamp: "<<img.getTime()<<std::endl;
+            std::cout<<"Basler diff: "<<grab_result->ChunkTimestamp.GetValue()-lastBaslerCaptureTime<<std::endl;
+            std::cout<<"Image diff: "<<img.getTime()-lastCaptureTime<<std::endl;
+            lastCaptureTime = img.getTime();
+            lastBaslerCaptureTime = grab_result->ChunkTimestamp.GetValue();
+        }else{
 		    std::cerr<<"Could not read TimeStamp!"<<std::endl;
 		}
 		if(GenApi::IsReadable(grab_result->ChunkFramecounter)){

--- a/src/shared/capture/capture_basler.cpp
+++ b/src/shared/capture/capture_basler.cpp
@@ -104,10 +104,8 @@ bool CaptureBasler::_buildCamera() {
 				Pylon::CTlFactory::GetInstance().CreateDevice(info));
         printf("Opening camera %d...\n", current_id);
 		camera->Open();
-        printf("Setting interpacket delay...\n");
         camera->GammaSelector.SetValue(Basler_GigECamera::GammaSelector_User); //Necessary for interface to work
         camera->AcquisitionFrameRateEnable.SetValue(true); //Turn on capped framerates
-        camera->GevSCPD.SetValue(0); // TODO: check this for multiple camera's
         //let camera send timestamps and FrameCounts.
 		if(GenApi::IsWritable(camera->ChunkModeActive)){
             camera->ChunkModeActive.SetValue(true);
@@ -117,6 +115,7 @@ bool CaptureBasler::_buildCamera() {
             camera->ChunkEnable.SetValue(true);
             camera->GevTimestampControlReset.Execute(); //Reset the internal time stamp counter of the camera to 0
         }else{
+		    std::cout<<"Failed, camera model does not support accurate timings!"<<std::endl;
 		    return false; //Camera does not support accurate timings
 		}
         printf("Done!\n");
@@ -331,11 +330,9 @@ void CaptureBasler::readAllParameterValues() {
 		return;
 	} catch (...) {
 		MUTEX_UNLOCK;
-		std::cout<<"End Read Parameters general exception"<<std::endl;
 		throw;
 	}
 	MUTEX_UNLOCK;
-	std::cout<<"End Read Parameters"<<std::endl;
 }
 
 void CaptureBasler::resetCamera(unsigned int new_id) {

--- a/src/shared/capture/capture_basler.cpp
+++ b/src/shared/capture/capture_basler.cpp
@@ -109,18 +109,17 @@ bool CaptureBasler::_buildCamera() {
         camera_frequency = camera->GevTimestampTickFrequency.GetValue();;
 
         //let camera send timestamps and FrameCounts.
-        if (GenApi::IsWritable(camera->ChunkModeActive)) {
-            camera->ChunkModeActive.SetValue(true);
-            camera->ChunkSelector.SetValue(Basler_GigECamera::ChunkSelector_Timestamp);
-            camera->ChunkEnable.SetValue(true);
-            camera->ChunkSelector.SetValue(Basler_GigECamera::ChunkSelector_Framecounter);
-            camera->ChunkEnable.SetValue(true);
-            camera->GevTimestampControlReset.Execute(); //Reset the internal time stamp counter of the camera to 0
-
-        } else {
-            std::cout << "Failed, camera model does not support accurate timings!" << std::endl;
-            return false; //Camera does not support accurate timings
-        }
+	if (GenApi::IsWritable(camera->ChunkModeActive)) {
+		camera->ChunkModeActive.SetValue(true);
+		camera->ChunkSelector.SetValue(Basler_GigECamera::ChunkSelector_Timestamp);
+		camera->ChunkEnable.SetValue(true);
+		camera->ChunkSelector.SetValue(Basler_GigECamera::ChunkSelector_Framecounter);
+		camera->ChunkEnable.SetValue(true);
+		camera->GevTimestampControlReset.Execute(); //Reset the internal time stamp counter of the camera to 0
+	} else {
+		std::cout << "Failed, camera model does not support accurate timings!" << std::endl;
+		return false; //Camera does not support accurate timings
+	}
         printf("Done!\n");
 		is_capturing = true;
 		return true;

--- a/src/shared/capture/capture_basler.h
+++ b/src/shared/capture/capture_basler.h
@@ -65,7 +65,7 @@ private:
 	bool is_capturing;
 	bool ignore_capture_failure;
 	Pylon::CBaslerGigEInstantCamera* camera;
-	Pylon::CGrabResultPtr grab_result;
+	Pylon::CBaslerGigEGrabResultPtr grab_result;
 	Pylon::CImageFormatConverter converter;
 	int current_id;
   	unsigned char* last_buf;

--- a/src/shared/capture/capture_basler.h
+++ b/src/shared/capture/capture_basler.h
@@ -59,7 +59,7 @@ public:
 
 	void readAllParameterValues();
 
-	void writeParameterValues(VarList* vars);
+	void writeParameterValues(VarList* varList);
 
 private:
 	bool is_capturing;
@@ -67,12 +67,12 @@ private:
 	Pylon::CBaslerGigEInstantCamera* camera;
 	Pylon::CBaslerGigEGrabResultPtr grab_result;
 	Pylon::CImageFormatConverter converter;
-	int current_id;
+	unsigned int current_id;
   	unsigned char* last_buf;
 
   	void addOffset(double offSet);
   	double getAverageOffset() const;
-  	std::array<double,10> offSetsCircularBuffer;
+  	std::array<double,10> offSetsCircularBuffer = {};
   	double totalOffSets = 0;
   	unsigned long currentWriteIndex = 0;
   	int size = 0;

--- a/src/shared/capture/capture_basler.h
+++ b/src/shared/capture/capture_basler.h
@@ -70,9 +70,12 @@ private:
 	int current_id;
   	unsigned char* last_buf;
 
-  	double initialOffset;
-  	double lastCaptureTime;
-  	long int lastBaslerCaptureTime;
+  	void addOffset(double offSet);
+  	double getAverageOffset() const;
+  	std::array<double,10> offSetsCircularBuffer;
+  	double totalOffSets = 0;
+  	unsigned long currentWriteIndex = 0;
+  	int size = 0;
 
   	VarList* vars;
   	VarInt* v_camera_id;

--- a/src/shared/capture/capture_basler.h
+++ b/src/shared/capture/capture_basler.h
@@ -70,6 +70,7 @@ private:
 	int current_id;
   	unsigned char* last_buf;
 
+  	double initialOffset;
   	double lastCaptureTime;
   	int lastBaslerCaptureTime;
 

--- a/src/shared/capture/capture_basler.h
+++ b/src/shared/capture/capture_basler.h
@@ -80,7 +80,7 @@ private:
   	VarInt* v_balance_ratio_green;
   	VarInt* v_balance_ratio_blue;
   	VarBool* v_auto_gain;
-  	VarDouble* v_gain;
+  	VarInt* v_gain;
   	VarBool* v_gamma_enable;
   	VarDouble* v_gamma;
   	VarDouble* v_black_level;

--- a/src/shared/capture/capture_basler.h
+++ b/src/shared/capture/capture_basler.h
@@ -79,6 +79,7 @@ private:
 
   	VarList* vars;
   	VarInt* v_camera_id;
+  	VarDouble* v_framerate;
   	VarInt* v_balance_ratio_red;
   	VarInt* v_balance_ratio_green;
   	VarInt* v_balance_ratio_blue;

--- a/src/shared/capture/capture_basler.h
+++ b/src/shared/capture/capture_basler.h
@@ -72,7 +72,7 @@ private:
 
   	double initialOffset;
   	double lastCaptureTime;
-  	int lastBaslerCaptureTime;
+  	long int lastBaslerCaptureTime;
 
   	VarList* vars;
   	VarInt* v_camera_id;

--- a/src/shared/capture/capture_basler.h
+++ b/src/shared/capture/capture_basler.h
@@ -70,6 +70,7 @@ private:
 	unsigned int current_id;
   	unsigned char* last_buf;
 
+  	int camera_frequency = 125000000;
   	void addOffset(double offSet);
   	double getAverageOffset() const;
   	std::array<double,100> offSetsCircularBuffer = {};

--- a/src/shared/capture/capture_basler.h
+++ b/src/shared/capture/capture_basler.h
@@ -70,6 +70,9 @@ private:
 	int current_id;
   	unsigned char* last_buf;
 
+  	double lastCaptureTime;
+  	int lastBaslerCaptureTime;
+
   	VarList* vars;
   	VarInt* v_camera_id;
   	VarInt* v_balance_ratio_red;

--- a/src/shared/capture/capture_basler.h
+++ b/src/shared/capture/capture_basler.h
@@ -72,10 +72,10 @@ private:
 
   	void addOffset(double offSet);
   	double getAverageOffset() const;
-  	std::array<double,10> offSetsCircularBuffer = {};
+  	std::array<double,100> offSetsCircularBuffer = {};
   	double totalOffSets = 0;
   	unsigned long currentWriteIndex = 0;
-  	int size = 0;
+  	unsigned int size = 0;
 
   	VarList* vars;
   	VarInt* v_camera_id;


### PR DESCRIPTION
This PR is related to fix issue #173.

The problem turned out to be two-fold.
First of all, we were (accidentally) building in debug. This was not a problem by itself, but it was one of the causes for this issue.

Because in this case, the processing of an image took longer than the interval between two camera frames, ssl-vision would sometimes skip frames from the camera. This, combined with the 'take latest image' strategy and the timestamping being done in SSL-vision, would cause periodic timing errors on the order of ~10 ms. 

Note other camera implementations might face the same issue if their capture rate is higher than the rate SSL-vision can process at and they use a process-latest-image strategy. (I would probably check if this is the case for camera's with large images, such as the ones used in competition).
 
Even though building in Release largely fixed the issue, we still wanted to use the timestamps provided by the camera itself. These were typically more reliable than the ones from ssl-vision. I implemented a moving average filter to measure the average delay between the camera time and the observation time by ssl-vision. Combining this with the time from the camera gives good accuracy on both a higher level (so that more than one camera can be used) and on a lower level (using the exact camera timing from the internal camera clock).

This PR also fixes various segfaults, bugs, exceptions and a deadlock in the basler module, and adds a framerate cap for the camera so that this issue can be prevented in the future.