### PR TITLE
Use the camera time by syncing it with the system time

### DIFF
--- a/src/shared/CMakeLists.txt.inc
+++ b/src/shared/CMakeLists.txt.inc
@@ -46,6 +46,7 @@ set (SHARED_SRCS
 	${shared_dir}/util/texture.cpp
   ${shared_dir}/util/framelimiter.cpp
 	${shared_dir}/util/initial_color_calibrator.cpp
+	${shared_dir}/util/TimeSync.cpp
 
 	${shared_dir}/vartypes/VarBase64.cpp
 	${shared_dir}/vartypes/VarNotifier.cpp

--- a/src/shared/capture/capture_basler.cpp
+++ b/src/shared/capture/capture_basler.cpp
@@ -250,7 +250,8 @@ RawImage CaptureBasler::getFrame() {
 
 		if(grab_result->GetPayloadType() == Pylon::PayloadType_ChunkData &&
 		GenApi::IsReadable(grab_result->ChunkTimestamp)){
-                    uint64_t  image_timestamp = grab_result->ChunkTimestamp.GetValue();
+                    double period = 1e9 / camera_frequency;
+                    uint64_t image_timestamp = period * grab_result->ChunkTimestamp.GetValue();
                     timeSync.update(image_timestamp);
                     double time = timeSync.sync(image_timestamp) / 1e9;
 		    img.setTime(time);

--- a/src/shared/capture/capture_basler.h
+++ b/src/shared/capture/capture_basler.h
@@ -72,6 +72,8 @@ private:
 	unsigned int current_id;
   	unsigned char* last_buf;
 
+        // freq should always be 125 MHz for Basler-ace-1300-75gc
+        int camera_frequency = 125e6;
   	VarList* vars;
   	VarInt* v_camera_id;
   	VarDouble* v_framerate;

--- a/src/shared/capture/capture_basler.h
+++ b/src/shared/capture/capture_basler.h
@@ -15,6 +15,7 @@
 #include <pylon/gige/BaslerGigEInstantCamera.h>
 #include <sys/time.h>
 #include "VarTypes.h"
+#include "TimeSync.h"
 
 // Unset 'interface' from pylon/api_autoconf.h which conflicts with variables in ssl-vision
 #undef interface
@@ -63,20 +64,13 @@ public:
 
 private:
 	bool is_capturing;
-	bool ignore_capture_failure;
+        TimeSync timeSync;
+        bool ignore_capture_failure;
 	Pylon::CBaslerGigEInstantCamera* camera;
 	Pylon::CBaslerGigEGrabResultPtr grab_result;
 	Pylon::CImageFormatConverter converter;
 	unsigned int current_id;
   	unsigned char* last_buf;
-
-  	int camera_frequency = 125000000;
-  	void addOffset(double offSet);
-  	double getAverageOffset() const;
-  	std::array<double,100> offSetsCircularBuffer = {};
-  	double totalOffSets = 0;
-  	unsigned long currentWriteIndex = 0;
-  	unsigned int size = 0;
 
   	VarList* vars;
   	VarInt* v_camera_id;

--- a/src/shared/capture/capture_spinnaker.cpp
+++ b/src/shared/capture/capture_spinnaker.cpp
@@ -222,7 +222,7 @@ bool CaptureSpinnaker::resetBus()
     mutex.lock();
 
     mutex.unlock();
-    
+
   return true;
 }
 
@@ -242,12 +242,12 @@ bool CaptureSpinnaker::stopCapture()
       fprintf(stderr, "Spinnaker: An error occurred while closing the device (error code: %d, '%s')\n", e.GetError(), e.GetFullErrorMessage());
     }
   }
-  
+
   vector<VarType *> tmp = capture_settings->getChildren();
   for (auto &i : tmp) {
     i->removeFlags( VARTYPE_FLAG_READONLY );
   }
-  
+
   return true;
 }
 
@@ -265,7 +265,7 @@ bool CaptureSpinnaker::startCapture()
 
   CameraList camList = pSystem->GetCameras();
   fprintf(stderr, "Spinnaker: Number of cams: %u\n", camList.GetSize());
-  
+
   if(cam_id >= camList.GetSize())
   {
     fprintf(stderr, "Spinnaker: Invalid cam_id: %u\n", cam_id);
@@ -344,7 +344,7 @@ bool CaptureSpinnaker::startCapture()
   for (auto &i : tmp) {
     i->addFlags( VARTYPE_FLAG_READONLY );
   }
-    
+
     mutex.unlock();
 
   writeAllParameterValues();
@@ -406,10 +406,11 @@ RawImage CaptureSpinnaker::getFrame()
     mutex.unlock();
     return result;
   }
-  
-  timeval tv{};
-  gettimeofday(&tv, nullptr);
-  result.setTime((double)tv.tv_sec + tv.tv_usec*(1.0E-6));
+
+  uint64_t  image_timestamp = pImage->GetTimeStamp();
+  timeSync.update(image_timestamp);
+  double time = timeSync.sync(image_timestamp) / 1e9;
+  result.setTime(time);
   result.setWidth((int) pImage->GetWidth());
   result.setHeight((int) pImage->GetHeight());
   result.setData((unsigned char*) pImage->GetData());

--- a/src/shared/capture/capture_spinnaker.h
+++ b/src/shared/capture/capture_spinnaker.h
@@ -30,6 +30,7 @@
 #include <spinnaker/SystemPtr.h>
 #include <spinnaker/CameraPtr.h>
 #include <spinnaker/ImagePtr.h>
+#include "TimeSync.h"
 
 // Unset 'interface' from spinnaker/SpinGenApi/Types.h which conflicts with variables in ssl-vision
 #undef interface
@@ -54,17 +55,18 @@
 class CaptureSpinnaker : public QObject, public CaptureInterface
 {
   Q_OBJECT
-  
+
   public slots:
   void changed(VarType * group);
-  
+
   protected:
   QMutex mutex;
-  
+
   public:
 
 protected:
   bool is_capturing;
+  TimeSync timeSync;
 
   //capture variables:
   VarInt    * v_cam_bus;
@@ -86,7 +88,7 @@ protected:
 
   VarList * capture_settings;
   VarList * dcam_parameters;
-  
+
   // Spinnaker specific data
   Spinnaker::SystemPtr pSystem;
   Spinnaker::CameraPtr pCam;

--- a/src/shared/util/TimeSync.cpp
+++ b/src/shared/util/TimeSync.cpp
@@ -1,0 +1,55 @@
+#include "TimeSync.h"
+
+const int BUFFER_SIZE = 30;
+const uint64_t MAX_AVG_DIFF = 3e8L;  // 300ms
+const uint64_t SYNC_ACCURACY = 1e6L; // 1ms
+
+TimeSync::TimeSync() { currentOffset = 0; }
+
+void TimeSync::update(uint64_t timestamp) {
+  timeval tv = {};
+  gettimeofday(&tv, nullptr);
+  uint64_t tRef = tv.tv_sec * 1e9L + tv.tv_usec * 1e3L;
+  uint64_t tSynced = timestamp - currentOffset;
+
+  int64_t diff = tRef - tSynced;
+  diffBuffer.push_back(diff);
+  if (diffBuffer.size() > BUFFER_SIZE)
+    diffBuffer.pop_front();
+  uint64_t avgDiff = labs(average(diffBuffer));
+
+  if ((avgDiff > MAX_AVG_DIFF) || !offsetBuffer.empty()) {
+    // Start syncing
+    if (offsetBuffer.empty()) {
+      std::cout << "Start syncing with system clock due to avgDiff=" << avgDiff << std::endl;
+    }
+    int64_t offset = timestamp - tRef;
+    offsetBuffer.push_back(offset);
+    if (offsetBuffer.size() > BUFFER_SIZE)
+      offsetBuffer.pop_front();
+    currentOffset = average(offsetBuffer);
+    if (avgDiff < SYNC_ACCURACY) {
+      // Converged, stop syncing with reference clock
+      std::cout << "Synced with system clock. offset=" << currentOffset
+                << "ns diff=" << avgDiff << "ns" << std::endl;
+      offsetBuffer.clear();
+    }
+  }
+}
+
+uint64_t TimeSync::sync(uint64_t timestamp) const {
+  return timestamp - currentOffset;
+}
+
+int64_t TimeSync::calcOffset(uint64_t tRef, uint64_t tOther) {
+  return tOther - tRef;
+}
+
+int64_t TimeSync::average(const std::deque<int64_t> &deque) {
+  int size = deque.size();
+  double avg = 0;
+  for (auto l : deque) {
+    avg += (double)l / size;
+  }
+  return avg;
+}

--- a/src/shared/util/TimeSync.h
+++ b/src/shared/util/TimeSync.h
@@ -1,0 +1,26 @@
+#ifndef SSL_VISION_TIMESYNC_H
+#define SSL_VISION_TIMESYNC_H
+
+#include <deque>
+#include <sys/time.h>
+#include <iostream>
+#include <cmath>
+
+class TimeSync {
+
+public:
+  TimeSync();
+
+  void update(uint64_t timestamp);
+  uint64_t sync(uint64_t timestamp) const;
+
+private:
+  int64_t currentOffset;
+  std::deque<int64_t> offsetBuffer;
+  std::deque<int64_t> diffBuffer;
+
+  static int64_t calcOffset(uint64_t tRef, uint64_t tOther);
+  static int64_t average(const std::deque<int64_t> &deque);
+};
+
+#endif // SSL_VISION_TIMESYNC_H


### PR DESCRIPTION
Some camera APIs provide a camera-internal time for each image. This is much more accurate than using the system time.

The camera-internal time must be converted to unix time, because consumers of the ssl-vision message expect the timestamp to be in unix time. This is especially important when using multiple ssl-vision instances.