### PR TITLE
Add ball model configuration to protobuf

### DIFF
--- a/src/app/plugins/plugin_publishgeometry.cpp
+++ b/src/app/plugins/plugin_publishgeometry.cpp
@@ -56,8 +56,8 @@ string PluginPublishGeometry::getName() {
 
 void PluginPublishGeometry::sendGeometry() {
   SSL_GeometryData geodata;
-  SSL_GeometryFieldSize * gfield = geodata.mutable_field();
-  _field.toProtoBuffer(*gfield);
+  _field.toProtoBuffer(*geodata.mutable_field());
+  _field.toProtoBuffer(*geodata.mutable_models());
   for (unsigned int i = 0; i < params.size(); i++) {
     int camId = params[i]->additional_calibration_information->camera_index->get();
     if(camId < 0 || camId >= _field.num_cameras_total->get()) {

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -122,6 +122,15 @@ int main(int argc, char *argv[])
                 printf("  -penalty_area_width=%d (mm)\n",field.penalty_area_width());
                 printf("  -field_lines_size=%d\n",field.field_lines_size());
                 printf("  -field_arcs_size=%d\n",field.field_arcs_size());
+                
+                const SSL_GeometryModels & models = geom.models();
+                printf("Field Models:\n");
+                printf("  -straight_two_phase:acc_roll=%f\n",models.straight_two_phase().acc_roll());
+                printf("  -straight_two_phase:acc_slide=%f\n",models.straight_two_phase().acc_slide());
+                printf("  -straight_two_phase:k_switch=%f\n",models.straight_two_phase().k_switch());
+                printf("  -chip_fixed_loss:damping_xy_first_hop=%f\n",models.chip_fixed_loss().damping_xy_first_hop());
+                printf("  -chip_fixed_loss:damping_xy_other_hops=%f\n",models.chip_fixed_loss().damping_xy_other_hops());
+                printf("  -chip_fixed_loss:damping_z=%f\n",models.chip_fixed_loss().damping_z());
 
                 int calib_n = geom.calib_size();
                 for (int i=0; i< calib_n; i++) {

--- a/src/shared/proto/messages_robocup_ssl_geometry.proto
+++ b/src/shared/proto/messages_robocup_ssl_geometry.proto
@@ -77,6 +77,8 @@ message SSL_GeometryCameraCalibration {
 // There are two phases with different accelerations during the ball kicks:
 // 1. Sliding
 // 2. Rolling
+// The full model is described in the TDP of ER-Force from 2016, which can be found here:
+// https://ssl.robocup.org/wp-content/uploads/2019/01/2016_ETDP_ER-Force.pdf
 message SSL_BallModelStraightTwoPhase {
   // Ball sliding acceleration [m/s^2] (should be negative)
   required double acc_slide = 1;

--- a/src/shared/proto/messages_robocup_ssl_geometry.proto
+++ b/src/shared/proto/messages_robocup_ssl_geometry.proto
@@ -73,9 +73,27 @@ message SSL_GeometryCameraCalibration {
   optional uint32 pixel_image_height = 17;
 }
 
+message SSL_BallModelStraightTwoPhase {
+  required double acc_slide = 1;
+  required double acc_roll = 2;
+  required double k_switch = 3;
+}
+
+message SSL_BallModelChipFixedLossPlusRolling {
+  required double chip_damping_xy_first_hop = 1;
+  required double chip_damping_xy_other_hops = 2;
+  required double chip_damping_z = 3;
+}
+
+message SSL_GeometryBallModels {
+  optional SSL_BallModelStraightTwoPhase straight_two_phase = 1;
+  optional SSL_BallModelChipFixedLossPlusRolling chip_fixed_loss_plus_rolling = 2;
+}
+
 message SSL_GeometryData {
   required SSL_GeometryFieldSize field = 1;
   repeated SSL_GeometryCameraCalibration calib = 2;
+  optional SSL_GeometryBallModels ball_models = 3;
 }
 
 enum SSL_FieldShapeType {

--- a/src/shared/proto/messages_robocup_ssl_geometry.proto
+++ b/src/shared/proto/messages_robocup_ssl_geometry.proto
@@ -90,22 +90,22 @@ message SSL_BallModelStraightTwoPhase {
 // Uses fixed damping factors for xy and z direction per hop.
 message SSL_BallModelChipFixedLoss {
   // Chip kick velocity damping factor in XY direction for the first hop
-  required double chip_damping_xy_first_hop = 1;
+  required double damping_xy_first_hop = 1;
   // Chip kick velocity damping factor in XY direction for all following hops
-  required double chip_damping_xy_other_hops = 2;
+  required double damping_xy_other_hops = 2;
   // Chip kick velocity damping factor in Z direction for all hops
-  required double chip_damping_z = 3;
+  required double damping_z = 3;
 }
 
-message SSL_GeometryBallModels {
+message SSL_GeometryModels {
   optional SSL_BallModelStraightTwoPhase straight_two_phase = 1;
-  optional SSL_BallModelChipFixedLoss chip_fixed_loss_plus_rolling = 2;
+  optional SSL_BallModelChipFixedLoss chip_fixed_loss = 2;
 }
 
 message SSL_GeometryData {
   required SSL_GeometryFieldSize field = 1;
   repeated SSL_GeometryCameraCalibration calib = 2;
-  optional SSL_GeometryBallModels ball_models = 3;
+  optional SSL_GeometryModels models = 3;
 }
 
 enum SSL_FieldShapeType {

--- a/src/shared/proto/messages_robocup_ssl_geometry.proto
+++ b/src/shared/proto/messages_robocup_ssl_geometry.proto
@@ -73,21 +73,33 @@ message SSL_GeometryCameraCalibration {
   optional uint32 pixel_image_height = 17;
 }
 
+// Two-Phase model for straight-kicked balls.
+// There are two phases with different accelerations during the ball kicks:
+// 1. Sliding
+// 2. Rolling
 message SSL_BallModelStraightTwoPhase {
+  // Ball sliding acceleration [m/s^2] (should be negative)
   required double acc_slide = 1;
+  // Ball rolling acceleration [m/s^2] (should be negative)
   required double acc_roll = 2;
+  // Fraction of the initial velocity where the ball starts to roll
   required double k_switch = 3;
 }
 
-message SSL_BallModelChipFixedLossPlusRolling {
+// Fixed-Loss model for chipped balls.
+// Uses fixed damping factors for xy and z direction per hop.
+message SSL_BallModelChipFixedLoss {
+  // Chip kick velocity damping factor in XY direction for the first hop
   required double chip_damping_xy_first_hop = 1;
+  // Chip kick velocity damping factor in XY direction for all following hops
   required double chip_damping_xy_other_hops = 2;
+  // Chip kick velocity damping factor in Z direction for all hops
   required double chip_damping_z = 3;
 }
 
 message SSL_GeometryBallModels {
   optional SSL_BallModelStraightTwoPhase straight_two_phase = 1;
-  optional SSL_BallModelChipFixedLossPlusRolling chip_fixed_loss_plus_rolling = 2;
+  optional SSL_BallModelChipFixedLoss chip_fixed_loss_plus_rolling = 2;
 }
 
 message SSL_GeometryData {

--- a/src/shared/util/field.h
+++ b/src/shared/util/field.h
@@ -128,6 +128,38 @@ private slots:
   void fillTypeEnum() const;
 };
 
+class BallModelStraightTwoPhase : public QObject {
+Q_OBJECT
+public:
+  VarDouble* accSlide;
+  VarDouble* accRoll;
+  VarDouble* kSwitch;
+  VarList* settings;
+  BallModelStraightTwoPhase();
+  ~BallModelStraightTwoPhase();
+};
+
+class BallModelChipFixLoss : public QObject {
+Q_OBJECT
+public:
+  VarDouble* dampingXyFirstHop;
+  VarDouble* dampingXyOtherHops;
+  VarDouble* dampingZ;
+  VarList* settings;
+  BallModelChipFixLoss();
+  ~BallModelChipFixLoss();
+};
+
+class RoboCupFieldModels : public QObject {
+  Q_OBJECT
+public:
+  BallModelStraightTwoPhase ballModelStraightTwoPhase;
+  BallModelChipFixLoss ballModelChipFixLoss;
+  VarList* settings;
+  RoboCupFieldModels();
+  ~RoboCupFieldModels();
+};
+
 class RoboCupField : public QObject {
 Q_OBJECT
 protected:
@@ -138,7 +170,8 @@ public:
     return settings;
   }
 
-  void toProtoBuffer(SSL_GeometryFieldSize& buffer) const ;
+  void toProtoBuffer(SSL_GeometryFieldSize& buffer) const;
+  void toProtoBuffer(SSL_GeometryModels& buffer) const;
 
   mutable QReadWriteLock field_markings_mutex;
   VarDouble* field_length;
@@ -157,6 +190,7 @@ public:
   VarList* field_arcs_list;
   vector<FieldLine*> field_lines;
   vector<FieldCircularArc*> field_arcs;
+  RoboCupFieldModels* field_models;
 
   RoboCupField();
   ~RoboCupField();


### PR DESCRIPTION
Most teams use some kind of ball model in their software to track and predict the ball. These models require certain parameters.

One common model for straight kicks is the two phase model, with a sliding and a rolling phase and a switch factor. It is used by ER-Force and TIGERs and their autoRefs.

Instead of doing the configuration for each software (especially the autoRefs) individually, it would be nice to have the parameters at a central place and read it from there.

This PR proposes to add the parameter to the ssl-vision protocol and allow configuration within ssl-vision.