### PR TITLE
Spinnaker

### DIFF
--- a/cmake/FindSPINNAKER.cmake
+++ b/cmake/FindSPINNAKER.cmake
@@ -5,11 +5,13 @@ unset(SPINNAKER_LIBS)
 find_path(SPINNAKER_INCLUDE_DIRS NAMES
         Spinnaker.h
         HINTS
+        /opt/spinnaker/include/
         /usr/include/spinnaker/
         /usr/local/include/spinnaker/)
 
 find_library(SPINNAKER_LIBS NAMES Spinnaker
         HINTS
+        /opt/spinnaker/lib
         /usr/lib
         /usr/local/lib)
 

--- a/src/shared/capture/capture_spinnaker.h
+++ b/src/shared/capture/capture_spinnaker.h
@@ -27,9 +27,9 @@
 #include <stdlib.h>
 #include <string>
 #include "VarTypes.h"
-#include <spinnaker/SystemPtr.h>
-#include <spinnaker/CameraPtr.h>
-#include <spinnaker/ImagePtr.h>
+#include <SystemPtr.h>
+#include <CameraPtr.h>
+#include <ImagePtr.h>
 #include "TimeSync.h"
 
 // Unset 'interface' from spinnaker/SpinGenApi/Types.h which conflicts with variables in ssl-vision

--- a/src/shared/capture/capture_spinnaker.h
+++ b/src/shared/capture/capture_spinnaker.h
@@ -22,21 +22,18 @@
 #ifndef CAPTURE_SPINNAKER_H
 #define CAPTURE_SPINNAKER_H
 #include "captureinterface.h"
-#include <sys/time.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string>
 #include "VarTypes.h"
-#include <SystemPtr.h>
-#include <CameraPtr.h>
-#include <ImagePtr.h>
+#include "Spinnaker.h"
 #include "TimeSync.h"
+
+#include <ctime>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <QMutex>
 
 // Unset 'interface' from spinnaker/SpinGenApi/Types.h which conflicts with variables in ssl-vision
 #undef interface
-
-  #include <QMutex>
-
 
 /*!
   \class  CaptureSpinnaker
@@ -50,8 +47,6 @@
   please inform the author, as we are aiming for complete camera
   coverage.
 */
-  #include <QMutex>
-  //if using QT, inherit QObject as a base
 class CaptureSpinnaker : public QObject, public CaptureInterface
 {
   Q_OBJECT


### PR DESCRIPTION
With the new major release of Spinnaker SDK, the currently used includes did not work anymore and cmake could not find the new installation location (under /opt).

This is fixed in this PR. While not tested, it should still work with version 1 of the SDK.