### PR TITLE
Add additional parameters to geometry field size

### DIFF
--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
                 printf("  -line_thickness=%d (mm)\n",field.line_thickness());
                 printf("  -goal_line_to_penalty_mark=%d (mm)\n",field.goal_center_to_penalty_mark());
                 printf("  -ball_radius=%.1f (mm)\n",field.ball_radius());
-                printf("  -robot_radius=%.1f (mm)\n",field.robot_radius());
+                printf("  -max_robot_radius=%.1f (mm)\n",field.max_robot_radius());
                 printf("  -field_lines_size=%d\n",field.field_lines_size());
                 printf("  -field_arcs_size=%d\n",field.field_arcs_size());
                 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -118,9 +118,14 @@ int main(int argc, char *argv[])
                 printf("  -boundary_width=%d (mm)\n",field.boundary_width());
                 printf("  -goal_width=%d (mm)\n",field.goal_width());
                 printf("  -goal_depth=%d (mm)\n",field.goal_depth());
+                printf("  -goal_height=%d (mm)\n",field.goal_height());
                 printf("  -penalty_area_depth=%d (mm)\n",field.penalty_area_depth());
                 printf("  -penalty_area_width=%d (mm)\n",field.penalty_area_width());
                 printf("  -center_circle_radius=%d (mm)\n",field.center_circle_radius());
+                printf("  -line_thickness=%d (mm)\n",field.line_thickness());
+                printf("  -goal_line_to_penalty_mark=%d (mm)\n",field.goal_center_to_penalty_mark());
+                printf("  -ball_radius=%.1f (mm)\n",field.ball_radius());
+                printf("  -robot_radius=%.1f (mm)\n",field.robot_radius());
                 printf("  -field_lines_size=%d\n",field.field_lines_size());
                 printf("  -field_arcs_size=%d\n",field.field_arcs_size());
                 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -120,6 +120,7 @@ int main(int argc, char *argv[])
                 printf("  -goal_depth=%d (mm)\n",field.goal_depth());
                 printf("  -penalty_area_depth=%d (mm)\n",field.penalty_area_depth());
                 printf("  -penalty_area_width=%d (mm)\n",field.penalty_area_width());
+                printf("  -center_circle_radius=%d (mm)\n",field.center_circle_radius());
                 printf("  -field_lines_size=%d\n",field.field_lines_size());
                 printf("  -field_arcs_size=%d\n",field.field_arcs_size());
                 

--- a/src/shared/proto/messages_robocup_ssl_geometry.proto
+++ b/src/shared/proto/messages_robocup_ssl_geometry.proto
@@ -52,6 +52,11 @@ message SSL_GeometryFieldSize {
   optional int32 penalty_area_depth = 8;
   optional int32 penalty_area_width = 9;
   optional int32 center_circle_radius = 10;
+  optional int32 line_thickness = 11;
+  optional int32 goal_center_to_penalty_mark = 12;
+  optional int32 goal_height = 13;
+  optional float ball_radius = 14;
+  optional float robot_radius = 15;
 }
 
 message SSL_GeometryCameraCalibration {

--- a/src/shared/proto/messages_robocup_ssl_geometry.proto
+++ b/src/shared/proto/messages_robocup_ssl_geometry.proto
@@ -56,7 +56,7 @@ message SSL_GeometryFieldSize {
   optional int32 goal_center_to_penalty_mark = 12;
   optional int32 goal_height = 13;
   optional float ball_radius = 14;
-  optional float robot_radius = 15;
+  optional float max_robot_radius = 15;
 }
 
 message SSL_GeometryCameraCalibration {

--- a/src/shared/proto/messages_robocup_ssl_geometry.proto
+++ b/src/shared/proto/messages_robocup_ssl_geometry.proto
@@ -51,6 +51,7 @@ message SSL_GeometryFieldSize {
   repeated SSL_FieldCircularArc field_arcs = 7;
   optional int32 penalty_area_depth = 8;
   optional int32 penalty_area_width = 9;
+  optional int32 center_circle_radius = 10;
 }
 
 message SSL_GeometryCameraCalibration {

--- a/src/shared/proto/messages_robocup_ssl_geometry.proto
+++ b/src/shared/proto/messages_robocup_ssl_geometry.proto
@@ -1,7 +1,9 @@
 syntax = "proto2";
 // A 2D float vector.
 message Vector2f {
+  // X-coordinate in mm
   required float x = 1;
+  // Y-coordinate in mm
   required float y = 2;
 }
 
@@ -42,20 +44,35 @@ message SSL_FieldCircularArc {
 }
 
 message SSL_GeometryFieldSize {
+  // Field length (distance between goal lines) in mm
   required int32 field_length = 1;
+  // Field width (distance between touch lines) in mm
   required int32 field_width = 2;
+  // Goal width (distance between inner edges of goal posts) in mm
   required int32 goal_width = 3;
+  // Goal depth (distance from outer goal line edge to inner goal back) in mm
   required int32 goal_depth = 4;
+  // Boundary width (distance from touch/goal line centers to boundary walls) in mm
   required int32 boundary_width = 5;
+  // Generated line segments based on the other parameters 
   repeated SSL_FieldLineSegment field_lines = 6;
+  // Generated circular arcs based on the other parameters
   repeated SSL_FieldCircularArc field_arcs = 7;
+  // Depth of the penalty/defense area (measured between line centers) in mm
   optional int32 penalty_area_depth = 8;
+  // Width of the penalty/defense area (measured between line centers) in mm
   optional int32 penalty_area_width = 9;
+  // Radius of the center circle (measured between line centers) in mm
   optional int32 center_circle_radius = 10;
+  // Thickness/width of the lines on the field in mm
   optional int32 line_thickness = 11;
+  // Distance between the goal center and the center of the penalty mark in mm 
   optional int32 goal_center_to_penalty_mark = 12;
+  // Goal height in mm
   optional int32 goal_height = 13;
+  // Ball radius in mm (note that this is a float type to represent sub-mm precision)
   optional float ball_radius = 14;
+  // Max allowed robot radius in mm (note that this is a float type to represent sub-mm precision)
   optional float max_robot_radius = 15;
 }
 

--- a/src/shared/util/field.cpp
+++ b/src/shared/util/field.cpp
@@ -676,7 +676,7 @@ void RoboCupField::updateFieldLinesAndArcs() {
     field_arcs.clear();
 
     // Load default arcs.
-    field_arcs.push_back(new FieldCircularArc("CenterCircle", 0, 0, FieldConstantsRoboCup2018A::kCenterCircleRadius, 0, 2.0 * M_PI, 10));
+    field_arcs.push_back(new FieldCircularArc("CenterCircle", 0, 0, center_circle_radius->getDouble(), 0, 2.0 * M_PI, 10));
 
     var_num_arcs->setInt(field_arcs.size());
     for (size_t i = 0; i < field_arcs.size(); ++i) {

--- a/src/shared/util/field.cpp
+++ b/src/shared/util/field.cpp
@@ -354,8 +354,8 @@ RoboCupField::RoboCupField() {
       "Center Circle Radius", FieldConstantsRoboCup2018A::kCenterCircleRadius);
   ball_radius = new VarDouble(
       "Ball Radius", FieldConstantsRoboCup2018A::kBallRadius);
-  robot_radius = new VarDouble(
-      "Robot Radius", FieldConstantsRoboCup2018A::kRobotRadius);
+  max_robot_radius = new VarDouble(
+      "Max Robot Radius", FieldConstantsRoboCup2018A::kMaxRobotRadius);
   num_cameras_total = new VarInt(
        "Total Number of Cameras", FieldConstantsRoboCup2018A::kNumCamerasTotal);
   num_cameras_local = new VarInt(
@@ -382,7 +382,7 @@ RoboCupField::RoboCupField() {
   settings->addChild(goal_center_to_penalty_mark);
   settings->addChild(center_circle_radius);
   settings->addChild(ball_radius);
-  settings->addChild(robot_radius);
+  settings->addChild(max_robot_radius);
   settings->addChild(num_cameras_total);
   settings->addChild(num_cameras_local);
   settings->addChild(var_num_lines);
@@ -433,7 +433,7 @@ RoboCupField::~RoboCupField() {
   delete goal_center_to_penalty_mark;
   delete center_circle_radius;
   delete ball_radius;
-  delete robot_radius;
+  delete max_robot_radius;
   delete num_cameras_total;
   delete num_cameras_local;
   delete var_num_lines;
@@ -471,7 +471,7 @@ void RoboCupField::toProtoBuffer(SSL_GeometryFieldSize& buffer) const {
   buffer.set_goal_center_to_penalty_mark((int)goal_center_to_penalty_mark->getDouble());
   buffer.set_goal_height((int) goal_height->getDouble());
   buffer.set_ball_radius((float) ball_radius->getDouble());
-  buffer.set_robot_radius((float) robot_radius->getDouble());
+  buffer.set_max_robot_radius((float) max_robot_radius->getDouble());
   
   for (size_t i = 0; i < field_lines.size(); ++i) {
     const FieldLine& line = *(field_lines[i]);

--- a/src/shared/util/field.cpp
+++ b/src/shared/util/field.cpp
@@ -338,6 +338,8 @@ RoboCupField::RoboCupField() {
       "Goal Width", FieldConstantsRoboCup2018A::kGoalWidth);
   goal_depth = new VarDouble(
       "Goal Depth", FieldConstantsRoboCup2018A::kGoalDepth);
+  goal_height = new VarDouble(
+      "Goal Height", FieldConstantsRoboCup2018A::kGoalHeight);
   boundary_width = new VarDouble(
       "Boundary Width", FieldConstantsRoboCup2018A::kBoundaryWidth);
   line_thickness = new VarDouble(
@@ -346,6 +348,14 @@ RoboCupField::RoboCupField() {
        "Penalty Area Depth", FieldConstantsRoboCup2018A::kPenaltyAreaDepth);
   penalty_area_width = new VarDouble(
        "Penalty Area Width", FieldConstantsRoboCup2018A::kPenaltyAreaWidth);
+  goal_center_to_penalty_mark = new VarDouble(
+      "Goal Line to Penalty Mark", FieldConstantsRoboCup2018A::kGoalLineToPenaltyMark);
+  center_circle_radius = new VarDouble(
+      "Center Circle Radius", FieldConstantsRoboCup2018A::kCenterCircleRadius);
+  ball_radius = new VarDouble(
+      "Ball Radius", FieldConstantsRoboCup2018A::kBallRadius);
+  robot_radius = new VarDouble(
+      "Robot Radius", FieldConstantsRoboCup2018A::kRobotRadius);
   num_cameras_total = new VarInt(
        "Total Number of Cameras", FieldConstantsRoboCup2018A::kNumCamerasTotal);
   num_cameras_local = new VarInt(
@@ -364,10 +374,15 @@ RoboCupField::RoboCupField() {
   settings->addChild(field_width);
   settings->addChild(goal_width);
   settings->addChild(goal_depth);
+  settings->addChild(goal_height);
   settings->addChild(boundary_width);
   settings->addChild(line_thickness);
   settings->addChild(penalty_area_depth);
   settings->addChild(penalty_area_width);
+  settings->addChild(goal_center_to_penalty_mark);
+  settings->addChild(center_circle_radius);
+  settings->addChild(ball_radius);
+  settings->addChild(robot_radius);
   settings->addChild(num_cameras_total);
   settings->addChild(num_cameras_local);
   settings->addChild(var_num_lines);
@@ -410,7 +425,19 @@ RoboCupField::~RoboCupField() {
   delete field_width;
   delete goal_width;
   delete goal_depth;
+  delete goal_height;
   delete boundary_width;
+  delete line_thickness;
+  delete penalty_area_depth;
+  delete penalty_area_width;
+  delete goal_center_to_penalty_mark;
+  delete center_circle_radius;
+  delete ball_radius;
+  delete robot_radius;
+  delete num_cameras_total;
+  delete num_cameras_local;
+  delete var_num_lines;
+  delete var_num_arcs;
   for (size_t i = 0; i < field_lines.size(); ++i) {
     delete field_lines[i];
   }
@@ -432,14 +459,20 @@ SSL_FieldShapeType RoboCupField::parseShapeType(const VarStringEnum* value) cons
 void RoboCupField::toProtoBuffer(SSL_GeometryFieldSize& buffer) const {
   field_markings_mutex.lockForRead();
   buffer.Clear();
-  buffer.set_field_length(field_length->getDouble());
-  buffer.set_field_width(field_width->getDouble());
-  buffer.set_goal_width(goal_width->getDouble());
-  buffer.set_goal_depth(goal_depth->getDouble());
-  buffer.set_boundary_width(boundary_width->getDouble());
-  buffer.set_penalty_area_depth(penalty_area_depth->getDouble());
-  buffer.set_penalty_area_width(penalty_area_width->getDouble());
-  buffer.set_center_circle_radius(FieldConstantsRoboCup2018A::kCenterCircleRadius);
+  buffer.set_field_length((int) field_length->getDouble());
+  buffer.set_field_width((int) field_width->getDouble());
+  buffer.set_goal_width((int) goal_width->getDouble());
+  buffer.set_goal_depth((int) goal_depth->getDouble());
+  buffer.set_boundary_width((int) boundary_width->getDouble());
+  buffer.set_penalty_area_depth((int) penalty_area_depth->getDouble());
+  buffer.set_penalty_area_width((int) penalty_area_width->getDouble());
+  buffer.set_center_circle_radius((int) center_circle_radius->getDouble());
+  buffer.set_line_thickness((int) line_thickness->getDouble());
+  buffer.set_goal_center_to_penalty_mark((int)goal_center_to_penalty_mark->getDouble());
+  buffer.set_goal_height((int) goal_height->getDouble());
+  buffer.set_ball_radius((float) ball_radius->getDouble());
+  buffer.set_robot_radius((float) robot_radius->getDouble());
+  
   for (size_t i = 0; i < field_lines.size(); ++i) {
     const FieldLine& line = *(field_lines[i]);
     SSL_FieldLineSegment proto_line;

--- a/src/shared/util/field.cpp
+++ b/src/shared/util/field.cpp
@@ -439,6 +439,7 @@ void RoboCupField::toProtoBuffer(SSL_GeometryFieldSize& buffer) const {
   buffer.set_boundary_width(boundary_width->getDouble());
   buffer.set_penalty_area_depth(penalty_area_depth->getDouble());
   buffer.set_penalty_area_width(penalty_area_width->getDouble());
+  buffer.set_center_circle_radius(FieldConstantsRoboCup2018A::kCenterCircleRadius);
   for (size_t i = 0; i < field_lines.size(); ++i) {
     const FieldLine& line = *(field_lines[i]);
     SSL_FieldLineSegment proto_line;

--- a/src/shared/util/field.h
+++ b/src/shared/util/field.h
@@ -178,10 +178,15 @@ public:
   VarDouble* field_width;
   VarDouble* goal_width;
   VarDouble* goal_depth;
+  VarDouble* goal_height;
   VarDouble* boundary_width;
   VarDouble* line_thickness;
   VarDouble* penalty_area_depth;
   VarDouble* penalty_area_width;
+  VarDouble* center_circle_radius;
+  VarDouble*goal_center_to_penalty_mark;
+  VarDouble* ball_radius;
+  VarDouble* robot_radius;
   VarInt* num_cameras_total;
   VarInt* num_cameras_local;
   VarInt* var_num_lines;

--- a/src/shared/util/field.h
+++ b/src/shared/util/field.h
@@ -186,7 +186,7 @@ public:
   VarDouble* center_circle_radius;
   VarDouble*goal_center_to_penalty_mark;
   VarDouble* ball_radius;
-  VarDouble* robot_radius;
+  VarDouble* max_robot_radius;
   VarInt* num_cameras_total;
   VarInt* num_cameras_local;
   VarInt* var_num_lines;

--- a/src/shared/util/field_default_constants.h
+++ b/src/shared/util/field_default_constants.h
@@ -42,7 +42,7 @@ namespace FieldConstantsRoboCup2018A {
     const double kCenterCircleRadius = 500.0;
     const double kGoalLineToPenaltyMark = 8000.0;
     const double kBallRadius = 21.5;
-    const double kRobotRadius = 90.0;
+    const double kMaxRobotRadius = 90.0;
     const int kNumCamerasTotal = 2;
     const int kNumCamerasLocal = 2;
 }

--- a/src/shared/util/field_default_constants.h
+++ b/src/shared/util/field_default_constants.h
@@ -34,12 +34,16 @@ namespace FieldConstantsRoboCup2018A {
     const double kFieldWidth = 9000.0;
     const double kGoalWidth = 1200.0;
     const double kGoalDepth = 180.0;
+    const double kGoalHeight = 155.0;
     const double kBoundaryWidth = 250.0;
     const double kLineThickness = 10.0;
     const double kPenaltyAreaDepth = 1200.0;
     const double kPenaltyAreaWidth = 2400.0;
     const double kCenterCircleRadius = 500.0;
-    const int kNumCamerasTotal = 8;
-    const int kNumCamerasLocal = 4;
+    const double kGoalLineToPenaltyMark = 8000.0;
+    const double kBallRadius = 21.5;
+    const double kRobotRadius = 90.0;
+    const int kNumCamerasTotal = 2;
+    const int kNumCamerasLocal = 2;
 }
 #endif // FIELD_H


### PR DESCRIPTION
The geometry field size message contains the dimension for the penalty area since recently, but some other dimensions are still missing:
* the penalty mark is missing completely
* the center circle radius still needs to be retrieved from the list of arcs.
* the line thickness needs to be retrieved from any/all lines/arcs and might be inconsistent
* goal height, ball radius and robot radius are missing

Some additional thoughts:

**Redundancy of parameters**: Some of the parameters can also be retrieved from the lines and arcs, so they would be redundant, but reading them from the lines/arcs is not a nice solution. Add adds extra complexity to the teams code, and they may also want to verify that the line dimensions are consistent for both teams.
The lines/arcs are primarily used by ssl-vision for calibration and depending on the field-setup, one might want to add/remove lines/arcs, if they are not painted on the field.

**Constant values**: Some parameters could be considered constant. The advantage of having them together with the rest is, that teams can retrieve all necessary dimensions from one place.