### PR TITLE
Add the framerate setting for the V4L camera

### DIFF
--- a/src/shared/capture/capturev4l.h
+++ b/src/shared/capture/capturev4l.h
@@ -113,7 +113,7 @@ public:
     bool setControl(int ctrl_id,long s);
     bool checkControl(int ctrl_id, bool *bEnabled=NULL, bool *bReadOnly=NULL,
                       long *lDefault=NULL, long *lMin=NULL, long *lMax=NULL);
-    bool startStreaming(int iWidth_, int iHeight_, uint32_t pixel_format, int iInput=0);
+    bool startStreaming(int iWidth_, int iHeight_, uint32_t pixel_format, int framerate, int iInput=0);
     bool stopStreaming();
     
     void captureWarm(int iMaxSpin=1);


### PR DESCRIPTION
In the previous code, it seemed that the framerate specified in the GUI was not reflected in behavior. 
This pull request adds a framerate argument to the GlobalV4Linstance::startStreaming() method.
I have confirmed that "Logicool c922n" works at 60 frames/sec in MJPEG format.