### PR TITLE
Fix(GlobalV4Linstance::getImageFromJPEG): remove memory leak

### DIFF
--- a/src/shared/capture/capturev4l.cpp
+++ b/src/shared/capture/capturev4l.cpp
@@ -583,6 +583,8 @@ bool GlobalV4Linstance::getImageFromJPEG(
     JSAMPROW row_ptr = &out_img->getData()[row_stride * row];
     jpeg_read_scanlines(&dinfo, &row_ptr, 1);
   }
+  // freeing jpeg_decompress_struct memory
+  jpeg_destroy_decompress(&dinfo);
   return true;
 }
 


### PR DESCRIPTION
Co-authored-by: felipemartins96 <fbm2@cin.ufpe.br>

Using MJPEG and V4L modules, we found a memory leak in this function. the struct jpeg_decompress_struct dinfo, has several pointers and allocates them in each iteration, but the added line does a free correctly and frees the memory after the conversion is finished