### PR TITLE
guard the inclusion of "capturedc1394v2.h" with DC1394

### DIFF
--- a/src/app/capture_thread.h
+++ b/src/app/capture_thread.h
@@ -21,7 +21,9 @@
 
 #ifndef CAPTURE_THREAD_H
 #define CAPTURE_THREAD_H
+#ifdef DC1394
 #include "capturedc1394v2.h"
+#endif
 #include "capturefromfile.h"
 #include "capturev4l.h"
 #include "capture_generator.h"


### PR DESCRIPTION
if  USE_DC1394 was false,  the inlusion caused the build to fail
apossible fix for #198