### PR TITLE
fix for using V4L-mjpeg

### DIFF
--- a/src/shared/capture/capturev4l.cpp
+++ b/src/shared/capture/capturev4l.cpp
@@ -586,7 +586,10 @@ bool GlobalV4Linstance::getImageFromJPEG(
   try{
     jpeg_create_decompress(&dinfo);
     jpeg_mem_src(&dinfo, in_img.data, in_img.length);
-    jpeg_read_header(&dinfo, true);
+    if (jpeg_read_header(&dinfo, true) != JPEG_HEADER_OK){
+      std::cout << "jpeg header is wrong" << std::endl;
+      return false;
+    }
     dinfo.output_components = 3;
     jpeg_start_decompress(&dinfo);
 
@@ -600,6 +603,7 @@ bool GlobalV4Linstance::getImageFromJPEG(
   }
   catch(std::runtime_error & e){
     jpeg_destroy_decompress(&dinfo);
+      std::cout << "an error occured using libjpeg" << std::endl;
     return false;
   }
   return true;

--- a/src/shared/capture/capturev4l.cpp
+++ b/src/shared/capture/capturev4l.cpp
@@ -587,7 +587,7 @@ bool GlobalV4Linstance::getImageFromJPEG(
     jpeg_create_decompress(&dinfo);
     jpeg_mem_src(&dinfo, in_img.data, in_img.length);
     if (jpeg_read_header(&dinfo, true) != JPEG_HEADER_OK){
-      std::cout << "jpeg header is wrong" << std::endl;
+      std::cout << "Warning: bad jpeg header" << std::endl;
       return false;
     }
     dinfo.output_components = 3;
@@ -603,7 +603,6 @@ bool GlobalV4Linstance::getImageFromJPEG(
   }
   catch(std::runtime_error & e){
     jpeg_destroy_decompress(&dinfo);
-      std::cout << "an error occured using libjpeg" << std::endl;
     return false;
   }
   return true;

--- a/src/shared/capture/capturev4l.h
+++ b/src/shared/capture/capturev4l.h
@@ -42,6 +42,7 @@
 #include "VarTypes.h"
 #include <linux/videodev2.h>
 #include <sys/poll.h>
+#include <jpeglib.h>
 
 #include <map>
 
@@ -144,8 +145,9 @@ public:
     static bool writeRgbPPM(GlobalV4Linstance::rgb *imgbuf, int width, int height, const char *filename);
 private:
     static bool getImageRgb(GlobalV4Linstance::yuyv *pSrc, int width, int height, GlobalV4Linstance::rgb **rgbbuf);
+    static void jpegErrorExit(j_common_ptr dinfo);
     static bool getImageFromJPEG(const image_t& in_img, RawImage* out_img);
-  static bool getImage(const image_t& in_img, const uint32_t pixel_format, RawImage* out_img);
+    static bool getImage(const image_t& in_img, const uint32_t pixel_format, RawImage* out_img);
     static GlobalV4Linstance::rgb yuv2rgb(GlobalV4Linstance::yuv p);
     
 };


### PR DESCRIPTION
Once bad jpeg image was got, Vision would terminate.
Then, I modified libjepg error handler.
cf. https://stackoverflow.com/questions/19857766/error-handling-in-libjpeg