### PR TITLE
Added default camera ID for Basler

### DIFF
--- a/src/app/capture_thread.cpp
+++ b/src/app/capture_thread.cpp
@@ -77,7 +77,7 @@ CaptureThread::CaptureThread(int cam_id)
   captureModule->addItem("Basler GigE");
   basler = new VarList("Basler GigE");
   settings->addChild(basler);
-  captureBasler = new CaptureBasler(basler);
+  captureBasler = new CaptureBasler(basler, camId);
 #endif
 
 #ifdef FLYCAP

--- a/src/shared/capture/capture_basler.cpp
+++ b/src/shared/capture/capture_basler.cpp
@@ -27,7 +27,7 @@ void BaslerInitManager::unregister_capture() {
 	}
 }
 
-CaptureBasler::CaptureBasler(VarList* _settings, QObject* parent) :
+CaptureBasler::CaptureBasler(VarList* _settings, int default_camera_id, QObject* parent) :
 		QObject(parent), CaptureInterface(_settings) {
 	is_capturing = false;
 	camera = nullptr;
@@ -45,7 +45,7 @@ CaptureBasler::CaptureBasler(VarList* _settings, QObject* parent) :
 	v_color_mode->addItem(Colors::colorFormatToString(COLOR_RGB8));
 	vars->addChild(v_color_mode);
 
-	vars->addChild(v_camera_id = new VarInt("Camera ID", 0, 0, 3));
+	vars->addChild(v_camera_id = new VarInt("Camera ID", default_camera_id, 0, 3));
 
 	v_framerate = new VarDouble("Max Framerate",100.0,0.0,100.0);
 	vars->addChild(v_framerate);

--- a/src/shared/capture/capture_basler.h
+++ b/src/shared/capture/capture_basler.h
@@ -40,7 +40,7 @@ private:
 	QMutex mutex;
 
 public:
-	CaptureBasler(VarList* _settings=0, QObject* parent=0);
+	CaptureBasler(VarList* _settings=0, int default_camera_id=0, QObject* parent=0);
     void mvc_connect(VarList * group);
 	~CaptureBasler();
 


### PR DESCRIPTION
With this, the Basler cameras are properly enumerated 0,1,2,3 instead of 0,0,0,0. Tested it, and it works.