### PR TITLE
Add new 't_capture_camera' to detection frame

### DIFF
--- a/src/app/capture_thread.cpp
+++ b/src/app/capture_thread.cpp
@@ -313,7 +313,9 @@ void CaptureThread::run() {
           auto t_start = std::chrono::steady_clock::now();
           RawImage pic_raw=capture->getFrame();
           auto t_getFrame = std::chrono::steady_clock::now();
-          d->time=pic_raw.getTime();
+          pic_raw.setTime(GetTimeSec());
+          d->time = pic_raw.getTime();
+          d->time_cam=pic_raw.getTimeCam();
           bool bSuccess = capture->copyAndConvertFrame( pic_raw,d->video);
           auto t_convert = std::chrono::steady_clock::now();
           capture_mutex.unlock();

--- a/src/app/framedata.cpp
+++ b/src/app/framedata.cpp
@@ -24,11 +24,11 @@
 FrameData::FrameData()
 {
   time=0;
+  time_cam=0;
   number=0;
 }
 
 
-FrameData::~FrameData()
-{}
+FrameData::~FrameData() = default;
 
 

--- a/src/app/framedata.h
+++ b/src/app/framedata.h
@@ -68,9 +68,9 @@ class FrameData
 {
 public:
   long long number;
-  int cam_id;
   double time;
-  RawImage video;//the video image from the camera (input)
+  double time_cam;
+  RawImage video; //the video image from the camera (input)
 
   FrameDataMap map; //all other data
 

--- a/src/app/plugins/plugin_legacysslnetworkoutput.cpp
+++ b/src/app/plugins/plugin_legacysslnetworkoutput.cpp
@@ -67,13 +67,18 @@ bool PluginLegacySSLNetworkOutput::DoubleSizeToSingleSize(
 ProcessResult PluginLegacySSLNetworkOutput::process(
     FrameData * data, RenderOptions * options) {
   (void)options;
-  if (data==0) return ProcessingFailed;
+  if (data== nullptr) return ProcessingFailed;
 
-  SSL_DetectionFrame * detection_frame = 0;
+  SSL_DetectionFrame * detection_frame;
 
   detection_frame=(SSL_DetectionFrame *)data->map.get("ssl_detection_frame");
-  if (detection_frame != 0) {
+  if (detection_frame != nullptr) {
     detection_frame->set_t_capture(data->time);
+    if (data->time_cam > 0) {
+      detection_frame->set_t_capture_camera(data->time_cam);
+    } else {
+      detection_frame->clear_t_capture_camera();
+    }
     detection_frame->set_frame_number(data->number);
     detection_frame->set_camera_id(_camera_params.additional_calibration_information->camera_index->getInt());
     detection_frame->set_t_sent(GetTimeSec());

--- a/src/app/plugins/plugin_sslnetworkoutput.cpp
+++ b/src/app/plugins/plugin_sslnetworkoutput.cpp
@@ -35,13 +35,18 @@ PluginSSLNetworkOutput::~PluginSSLNetworkOutput()
 ProcessResult PluginSSLNetworkOutput::process(FrameData * data, RenderOptions * options)
 {
   (void)options;
-  if (data==0) return ProcessingFailed;
+  if (data == nullptr) return ProcessingFailed;
 
-  SSL_DetectionFrame * detection_frame = 0;
+  SSL_DetectionFrame * detection_frame;
 
   detection_frame=(SSL_DetectionFrame *)data->map.get("ssl_detection_frame");
-  if (detection_frame != 0) {
+  if (detection_frame != nullptr) {
     detection_frame->set_t_capture(data->time);
+    if (data->time_cam > 0) {
+      detection_frame->set_t_capture_camera(data->time_cam);
+    } else {
+      detection_frame->clear_t_capture_camera();
+    }
     detection_frame->set_frame_number(data->number);
     detection_frame->set_camera_id(_camera_params.additional_calibration_information->camera_index->getInt());
     detection_frame->set_t_sent(GetTimeSec());
@@ -59,7 +64,7 @@ PluginSSLNetworkOutputSettings::PluginSSLNetworkOutputSettings()
   settings = new VarList("Network Output");
 
   settings->addChild(multicast_address = new VarString("Multicast Address","224.5.23.2"));
-  settings->addChild(multicast_port = 
+  settings->addChild(multicast_port =
       new VarInt("Multicast Port",10006,1,65535));
   settings->addChild(multicast_interface = new VarString("Multicast Interface",""));
 }

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
 
                 printf("-[Detection Data]-------\n");
                 //Frame info:
-                printf("Camera ID=%d FRAME=%d T_CAPTURE=%.4f\n",detection.camera_id(),detection.frame_number(),detection.t_capture());
+                printf("Camera ID=%d FRAME=%d T_CAPTURE=%.4f T_CAPTURE_CAM=%.4f\n",detection.camera_id(),detection.frame_number(),detection.t_capture(), detection.t_capture_camera());
 
                 printf("SSL-Vision Processing Latency                   %7.3fms\n",(detection.t_sent()-detection.t_capture())*1000.0);
                 printf("Network Latency (assuming synched system clock) %7.3fms\n",(t_now-detection.t_sent())*1000.0);
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
                 printf("  -max_robot_radius=%.1f (mm)\n",field.max_robot_radius());
                 printf("  -field_lines_size=%d\n",field.field_lines_size());
                 printf("  -field_arcs_size=%d\n",field.field_arcs_size());
-                
+
                 const SSL_GeometryModels & models = geom.models();
                 printf("Field Models:\n");
                 printf("  -straight_two_phase:acc_roll=%f\n",models.straight_two_phase().acc_roll());

--- a/src/shared/capture/capture_basler.cpp
+++ b/src/shared/capture/capture_basler.cpp
@@ -288,6 +288,7 @@ bool CaptureBasler::copyAndConvertFrame(const RawImage & src,
 	try {
 		target.ensure_allocation(COLOR_RGB8, src.getWidth(), src.getHeight());
 		target.setTime(src.getTime());
+		target.setTimeCam (src.getTimeCam());
 		memcpy(target.getData(), src.getData(), src.getNumBytes());
 	} catch (...) {
 		MUTEX_UNLOCK;

--- a/src/shared/capture/capture_bluefox2.cpp
+++ b/src/shared/capture/capture_bluefox2.cpp
@@ -26,7 +26,7 @@ CaptureBlueFox2::CaptureBlueFox2(VarList * _settings,int default_camera_id, QObj
   cam_id = static_cast<unsigned int>(default_camera_id);
   is_capturing = false;
   pDevMgr = nullptr;
-  
+
     mutex.lock();
 
   settings->addChild(capture_settings = new VarList("Capture Settings"));
@@ -44,7 +44,7 @@ CaptureBlueFox2::CaptureBlueFox2(VarList * _settings,int default_camera_id, QObj
   v_expose_us = new VarInt("Expose [us]", 2000, 10, 100000);
   v_expose_overlapped = new VarBool("Expose Overlapped", true);
   v_gain_db = new VarDouble("Gain [dB]", 0.0, 0.0, 12.0);
-  
+
   v_hdr_mode = new VarStringEnum("HDR Mode", hdrModeToString(HDR_MODE_OFF));
   v_hdr_mode->addItem(hdrModeToString(HDR_MODE_OFF));
   v_hdr_mode->addItem(hdrModeToString(HDR_MODE_FIXED0));
@@ -53,7 +53,7 @@ CaptureBlueFox2::CaptureBlueFox2(VarList * _settings,int default_camera_id, QObj
   v_hdr_mode->addItem(hdrModeToString(HDR_MODE_FIXED3));
   v_hdr_mode->addItem(hdrModeToString(HDR_MODE_FIXED4));
   v_hdr_mode->addItem(hdrModeToString(HDR_MODE_FIXED5));
-  
+
   v_mirror_top_down = new VarBool("Mirror Top/Down");
   v_mirror_left_right = new VarBool("Mirror Left/Right");
   v_wb_red = new VarDouble("WB Red", 1.0, 0.1, 10.0);
@@ -61,7 +61,7 @@ CaptureBlueFox2::CaptureBlueFox2(VarList * _settings,int default_camera_id, QObj
   v_wb_blue = new VarDouble("WB Blue", 1.0, 0.1, 10.0);
   v_sharpen = new VarBool("Sharpen", true);
   v_gamma = new VarDouble("Gamma", 1.0, 0.01, 10.0);
-  
+
   v_color_twist_mode = new VarStringEnum("Color Twist", colorTwistModeToString(COLOR_TWIST_MODE_SRGB_D50));
   v_color_twist_mode->addItem(colorTwistModeToString(COLOR_TWIST_MODE_OFF));
   v_color_twist_mode->addItem(colorTwistModeToString(COLOR_TWIST_MODE_ADOBERGB_D50));
@@ -69,12 +69,12 @@ CaptureBlueFox2::CaptureBlueFox2(VarList * _settings,int default_camera_id, QObj
   v_color_twist_mode->addItem(colorTwistModeToString(COLOR_TWIST_MODE_WIDE_GAMUT_RGB_D50));
   v_color_twist_mode->addItem(colorTwistModeToString(COLOR_TWIST_MODE_ADOBERGB_D65));
   v_color_twist_mode->addItem(colorTwistModeToString(COLOR_TWIST_MODE_SRGB_D65));
-  
+
   v_aoi_width = new VarInt("AOI width", 752, 0, 752);
   v_aoi_height = new VarInt("AOI height", 480, 0, 480);
   v_aoi_left = new VarInt("AOI left", 0, 0, 752);
   v_aoi_top = new VarInt("AOI top", 0, 0, 480);
-  
+
   v_pixel_clock = new VarStringEnum("Pixel Clock", pixelClockToString(cpc40000KHz));
   v_pixel_clock->addItem(pixelClockToString(cpc6000KHz));
   v_pixel_clock->addItem(pixelClockToString(cpc8000KHz));
@@ -85,7 +85,7 @@ CaptureBlueFox2::CaptureBlueFox2(VarList * _settings,int default_camera_id, QObj
   v_pixel_clock->addItem(pixelClockToString(cpc27000KHz));
   v_pixel_clock->addItem(pixelClockToString(cpc32000KHz));
   v_pixel_clock->addItem(pixelClockToString(cpc40000KHz));
-  
+
   dcam_parameters->addChild(v_aoi_width);
   dcam_parameters->addChild(v_aoi_height);
   dcam_parameters->addChild(v_aoi_left);
@@ -103,7 +103,7 @@ CaptureBlueFox2::CaptureBlueFox2(VarList * _settings,int default_camera_id, QObj
   dcam_parameters->addChild(v_sharpen);
   dcam_parameters->addChild(v_gamma);
   dcam_parameters->addChild(v_color_twist_mode);
-  
+
     mvc_connect(dcam_parameters);
     mutex.unlock();
 }
@@ -141,12 +141,12 @@ void CaptureBlueFox2::readParameterValues(VarList * item)
 {
   if(item != dcam_parameters)
     return;
-  
+
     mutex.lock();
-    
+
     // TODO: could do a read-out, but why?
 //   v_expose_us->setInt(pSettings->expose_us.read());
-    
+
     mutex.unlock();
 }
 
@@ -156,25 +156,25 @@ void CaptureBlueFox2::writeParameterValues(VarList * item)
     return;
 
     mutex.lock();
-    
+
   pSettings->pixelClock_KHz.write(stringToPixelClock(v_pixel_clock->getString().c_str()));
 
   pSettings->expose_us.write(v_expose_us->getInt());
-  
+
   if(v_expose_overlapped->getBool())
     pSettings->exposeMode.write(cemOverlapped);
   else
     pSettings->exposeMode.write(cemStandard);
-  
+
   pSettings->gain_dB.write(v_gain_db->getDouble());
-  
+
   pSettings->aoiStartX.write(v_aoi_left->getInt());
   pSettings->aoiStartY.write(v_aoi_top->getInt());
   pSettings->aoiWidth.write(v_aoi_width->getInt());
   pSettings->aoiHeight.write(v_aoi_height->getInt());
-  
+
   HDRMode hdrMode = stringToHdrMode(v_hdr_mode->getString().c_str());
-  
+
   if(hdrMode == HDR_MODE_OFF)
   {
     pSettings->getHDRControl().HDREnable.write(bFalse);
@@ -182,9 +182,9 @@ void CaptureBlueFox2::writeParameterValues(VarList * item)
   else
   {
     pSettings->getHDRControl().HDREnable.write(bTrue);
-    
+
     TCameraHDRMode hdr;
-    
+
     switch(hdrMode)
     {
       case HDR_MODE_FIXED0: hdr = cHDRmFixed0; break;
@@ -194,19 +194,19 @@ void CaptureBlueFox2::writeParameterValues(VarList * item)
       case HDR_MODE_FIXED4: hdr = cHDRmFixed4; break;
       default: hdr = cHDRmFixed5; break;
     }
-    
+
     pSettings->getHDRControl().HDRMode.write(hdr);
   }
-  
+
   int mm = mmOff;
   if(v_mirror_top_down->getBool())
     mm |= mmTopDown;
   if(v_mirror_left_right->getBool())
     mm |= mmLeftRight;
-  
+
   pImageProc->mirrorOperationMode.write(momGlobal);
   pImageProc->mirrorModeGlobal.write((TMirrorMode)mm);
-  
+
   pImageProc->whiteBalance.write(wbpUser1);
   WhiteBalanceSettings& wb = pImageProc->getWBUserSetting(0);
   wb.WBAoiMode.write(amFull);
@@ -214,12 +214,12 @@ void CaptureBlueFox2::writeParameterValues(VarList * item)
   wb.redGain.write(v_wb_red->getDouble());
   wb.greenGain.write(v_wb_green->getDouble());
   wb.blueGain.write(v_wb_blue->getDouble());
-  
+
   if(v_sharpen->getBool())
     pImageProc->filter.write(ipfSharpen);
   else
     pImageProc->filter.write(ipfOff);
-  
+
   pImageProc->LUTEnable.write(bTrue);
   pImageProc->LUTMode.write(LUTmGamma);
   pImageProc->LUTImplementation.write(LUTiSoftware);
@@ -228,9 +228,9 @@ void CaptureBlueFox2::writeParameterValues(VarList * item)
   pImageProc->getLUTParameter(1).gamma.write(v_gamma->getDouble());
   pImageProc->getLUTParameter(2).gamma.write(v_gamma->getDouble());
   pImageProc->getLUTParameter(3).gamma.write(v_gamma->getDouble());
-  
+
   ColorTwistMode ctMode = stringToColorTwistMode(v_color_twist_mode->getString().c_str());
-  
+
   if(ctMode == COLOR_TWIST_MODE_OFF)
   {
     pImageProc->colorTwistInputCorrectionMatrixEnable.write(bFalse);
@@ -243,7 +243,7 @@ void CaptureBlueFox2::writeParameterValues(VarList * item)
     pImageProc->colorTwistInputCorrectionMatrixMode.write(cticmmDeviceSpecific);
     pImageProc->colorTwistEnable.write(bTrue);
     pImageProc->colorTwistOutputCorrectionMatrixEnable.write(bTrue);
-    
+
     int ct;
     switch(ctMode)
     {
@@ -253,7 +253,7 @@ void CaptureBlueFox2::writeParameterValues(VarList * item)
       case COLOR_TWIST_MODE_ADOBERGB_D65: ct = ctocmmXYZToAdobeRGB_D65; break;
       default: ct = ctocmmXYZTosRGB_D65; break;
     }
-    
+
     pImageProc->colorTwistOutputCorrectionMatrixMode.write((TColorTwistOutputCorrectionMatrixMode)ct);
   }
 
@@ -272,7 +272,7 @@ bool CaptureBlueFox2::resetBus()
     mutex.lock();
 
     mutex.unlock();
-    
+
   return true;
 }
 
@@ -281,24 +281,24 @@ bool CaptureBlueFox2::stopCapture()
   if (isCapturing())
   {
     readAllParameterValues();
-    
+
     delete pFI;
     delete pSettings;
     delete pImageProc;
-    
+
     pDevice->close();
-    
+
     is_capturing = false;
   }
-  
+
   vector<VarType *> tmp = capture_settings->getChildren();
   for (unsigned int i=0; i < tmp.size();i++)
   {
     tmp[i]->removeFlags( VARTYPE_FLAG_READONLY );
   }
-  
+
   dcam_parameters->addFlags( VARTYPE_FLAG_HIDE_CHILDREN );
-  
+
   return true;
 }
 
@@ -309,13 +309,13 @@ bool CaptureBlueFox2::startCapture()
   if(pDevMgr == nullptr) {
     pDevMgr = new DeviceManager();
   }
-    
+
   //grab current parameters:
   cam_id = static_cast<unsigned int>(v_cam_bus->getInt());
-  
+
   const unsigned int devCnt = pDevMgr->deviceCount();
   fprintf(stderr, "BlueFox2: Number of cams: %u\n", devCnt);
-  
+
   if(cam_id >= devCnt)
   {
     fprintf(stderr, "BlueFox2: Invalid cam_id: %u\n", cam_id);
@@ -325,7 +325,7 @@ bool CaptureBlueFox2::startCapture()
   }
 
   pDevice = (*pDevMgr)[cam_id];
-  
+
   try
   {
     pDevice->open();
@@ -337,14 +337,14 @@ bool CaptureBlueFox2::startCapture()
       mutex.unlock();
     return false;
   }
-  
+
   fprintf(stderr, "BlueFox2: Opened: %s with serial ID %s\n", pDevice->family.read().c_str(), pDevice->serial.read().c_str());
-  
+
   pFI = new FunctionInterface(pDevice);
-  
+
   ImageDestination id( pDevice );
   id.restoreDefault();
-  
+
   ColorFormat out_color = Colors::stringToColorFormat(v_colorout->getSelection().c_str());
   if(out_color == COLOR_RGB8)
   {
@@ -354,48 +354,49 @@ bool CaptureBlueFox2::startCapture()
   {
     id.pixelFormat.write(idpfYUV422Packed);
   }
-  
+
   pSettings = new CameraSettingsBlueFOX(pDevice);
   pSettings->restoreDefault();
-  
+
   pImageProc = new ImageProcessing(pDevice);
   pImageProc->restoreDefault();
-  
+
   is_capturing = true;
-  
+
   vector<VarType *> tmp = capture_settings->getChildren();
   for (unsigned int i=0; i < tmp.size();i++) {
     tmp[i]->addFlags( VARTYPE_FLAG_READONLY );
   }
-    
+
   dcam_parameters->removeFlags( VARTYPE_FLAG_HIDE_CHILDREN );
 
     mutex.unlock();
-    
+
   printf("BlueFox2 Info: Restoring Previously Saved Camera Parameters\n");
   writeAllParameterValues();
   readAllParameterValues();
-  
+
   return true;
 }
 
 bool CaptureBlueFox2::copyAndConvertFrame(const RawImage & src, RawImage & target)
 {
     mutex.lock();
-    
+
   ColorFormat src_fmt = src.getColorFormat();
-  
+
   if(target.getData() == 0)
   {
     //allocate target, if it does not exist yet
     target.allocate(src_fmt, src.getWidth(), src.getHeight());
-  } 
+  }
   else
   {
     target.ensure_allocation(src_fmt, src.getWidth(), src.getHeight());
   }
   target.setTime(src.getTime());
-  
+  target.setTimeCam ( src.getTimeCam() );
+
   if(src.getColorFormat() == COLOR_RGB8)
   {
     memcpy(target.getData(),src.getData(),src.getNumBytes());
@@ -408,7 +409,7 @@ bool CaptureBlueFox2::copyAndConvertFrame(const RawImage & src, RawImage & targe
       target.getData()[i] = src.getData()[i+1];
     }
   }
-  
+
     mutex.unlock();
 
   return true;
@@ -417,17 +418,17 @@ bool CaptureBlueFox2::copyAndConvertFrame(const RawImage & src, RawImage & targe
 RawImage CaptureBlueFox2::getFrame()
 {
     mutex.lock();
-    
+
   RawImage result;
   result.setColorFormat(capture_format);
   result.setWidth(0);
   result.setHeight(0);
   result.setTime(0.0);
   result.setData(0);
-  
+
   // make sure the request queue is always filled
   while((static_cast<TDMR_ERROR>( pFI->imageRequestSingle() ) ) == DMR_NO_ERROR ) {};
-  
+
   int requestNr = pFI->imageRequestWaitFor(-1);
 
   // check if the image has been captured without any problems.
@@ -460,24 +461,24 @@ RawImage CaptureBlueFox2::getFrame()
   {
     fprintf(stderr, "BlueFox2: request not OK\n");
   }
-  
+
   lastRequestNr = requestNr;
-  
+
     mutex.unlock();
   return result;
 }
 
-void CaptureBlueFox2::releaseFrame() 
+void CaptureBlueFox2::releaseFrame()
 {
     mutex.lock();
-    
+
   if(pFI->isRequestNrValid(lastRequestNr))
     pFI->imageRequestUnlock(lastRequestNr);
-  
+
     mutex.unlock();
 }
 
-string CaptureBlueFox2::getCaptureMethodName() const 
+string CaptureBlueFox2::getCaptureMethodName() const
 {
   return "BlueFox2";
 }

--- a/src/shared/capture/capture_flycap.cpp
+++ b/src/shared/capture/capture_flycap.cpp
@@ -559,6 +559,7 @@ bool CaptureFlycap::convertFrame(const RawImage & src,
     target.ensure_allocation(output_fmt,src.getWidth(),src.getHeight());
   }
   target.setTime(src.getTime());
+  target.setTimeCam ( src.getTimeCam() );
   if (output_fmt==src_fmt) {
     //just do a memcpy
     memcpy(target.getData(),src.getData(),src.getNumBytes());
@@ -627,10 +628,6 @@ RawImage CaptureFlycap::getFrame() {
   Image image;
   RawImage result;
   result.setColorFormat(capture_format);
-  result.setWidth(0);
-  result.setHeight(0);
-  result.setTime(0.0);
-  result.setData(0);
   error = camera->RetrieveBuffer(&image);
   if (error != PGRERROR_OK) {
     error.PrintErrorTrace();
@@ -642,9 +639,6 @@ RawImage CaptureFlycap::getFrame() {
   stored_image->DeepCopy(&image);
 
   result.setData(stored_image->GetData());
-  struct timeval tv;
-  gettimeofday(&tv,NULL);
-  result.setTime((double)tv.tv_sec + tv.tv_usec*(1.0E-6));
   result.setHeight(stored_image->GetRows());
   result.setWidth(stored_image->GetCols());
   result.setColorFormat(pixelFormatToColorFormat(stored_image->GetPixelFormat()));

--- a/src/shared/capture/capture_generator.cpp
+++ b/src/shared/capture/capture_generator.cpp
@@ -82,6 +82,7 @@ bool CaptureGenerator::copyAndConvertFrame ( const RawImage & src, RawImage & ta
     target.ensure_allocation ( output_fmt, src.getWidth(), src.getHeight() );
   }
   target.setTime ( src.getTime() );
+  target.setTimeCam ( src.getTimeCam() );
 
   if ( output_fmt == src_fmt ) {
     if ( src.getData() != 0 ) memcpy ( target.getData(),src.getData(),src.getNumBytes() );
@@ -109,6 +110,7 @@ RawImage CaptureGenerator::getFrame()
   limit.waitForNextFrame();
   result.setColorFormat ( COLOR_RGB8 );
   result.setTime ( GetTimeSec() );
+  result.setTimeCam( GetTimeSec() );
   result.allocate ( COLOR_RGB8,v_width->getInt(),v_height->getInt() );
   rgbImage img;
   img.fromRawImage(result);

--- a/src/shared/capture/capture_spinnaker.h
+++ b/src/shared/capture/capture_spinnaker.h
@@ -68,7 +68,6 @@ private:
     // capture parameters
     VarInt *v_cam_bus;
     VarStringEnum *v_convert_to_mode;
-    VarBool *v_use_camera_time;
 
     // camera parameters
     VarBool *v_acquisition;

--- a/src/shared/capture/capture_splitter.cpp
+++ b/src/shared/capture/capture_splitter.cpp
@@ -92,6 +92,7 @@ bool CaptureSplitter::copyAndConvertFrame(const RawImage &src, RawImage &target)
     return false;
   }
   target.setTime(src.getTime());
+  target.setTimeCam ( src.getTimeCam() );
 
   // make sure we use values from 0 to 1
   double rel_height_offset = std::min(1.0, std::max(0.0, relative_height_offset->getDouble()));

--- a/src/shared/capture/capturedc1394v2.cpp
+++ b/src/shared/capture/capturedc1394v2.cpp
@@ -1441,6 +1441,7 @@ bool CaptureDC1394v2::convertFrame(const RawImage & src, RawImage & target, Colo
     //target.setFormat(output_fmt);
   }
   target.setTime(src.getTime());
+  target.setTimeCam ( src.getTimeCam() );
   if (output_fmt==src_fmt) {
     //just do a memcpy
     memcpy(target.getData(),src.getData(),src.getNumBytes());
@@ -1506,14 +1507,11 @@ bool CaptureDC1394v2::convertFrame(const RawImage & src, RawImage & target, Colo
 
 RawImage CaptureDC1394v2::getFrame()
 {
-    mutex.lock();
+  mutex.lock();
   RawImage result;
   result.setColorFormat(capture_format);
   result.setWidth(width);
   result.setHeight(height);
-  //result.size= RawImage::computeImageSize(format, width*height);
-  timeval tv;
-  result.setTime(0.0);
 
   if (dc1394_capture_dequeue(camera, DC1394_CAPTURE_POLICY_WAIT, &frame)!=DC1394_SUCCESS) {
     fprintf (stderr, "CaptureDC1394v2 Error: Failed to capture from camera %d\n", cam_id);
@@ -1532,13 +1530,9 @@ RawImage CaptureDC1394v2::getFrame()
     if (dc1394_capture_is_frame_corrupt (camera, frame) == DC1394_TRUE) {
       printf("============================CORRUPT!\n"); fflush(stdout); exit(1);
     }*/
-    gettimeofday(&tv,NULL);
-    result.setTime((double)tv.tv_sec + tv.tv_usec*(1.0E-6));
     result.setData(frame->image);
-
-    /*printf("B: %d w: %d h: %d bytes: %d pad: %d pos: %d %d depth: %d bpp %d coding: %d  behind %d id %d\n",frame->data_in_padding ? 1 : 0, frame->size[0],frame->size[1],frame->image_bytes,frame->padding_bytes, frame->position[0],frame->position[1],frame->data_depth,frame->packets_per_frame,frame->color_coding,frame->frames_behind,frame->id);*/
   }
-    mutex.unlock();
+  mutex.unlock();
   return result;
 }
 

--- a/src/shared/capture/capturefromfile.cpp
+++ b/src/shared/capture/capturefromfile.cpp
@@ -200,6 +200,7 @@ bool CaptureFromFile::copyAndConvertFrame(const RawImage & src, RawImage & targe
 
   target.ensure_allocation(output_fmt, src.getWidth(), src.getHeight());
   target.setTime(src.getTime());
+  target.setTimeCam ( src.getTimeCam() );
   if (output_fmt == src_fmt)
   {
     memcpy(target.getData(), src.getData(), static_cast<size_t>(src.getNumBytes()));
@@ -254,17 +255,11 @@ RawImage CaptureFromFile::getFrame()
   {
     fprintf (stderr, "CaptureFromFile Error, no images available");
     is_capturing=false;
-    result.setData(nullptr);
     result.setWidth(640);
     result.setHeight(480);
-    result.setTime(0.0);
   } else {
     result = images[currentImageIndex];
     currentImageIndex = static_cast<unsigned int>((currentImageIndex + 1) % images.size());
-
-    timeval tv{};
-    gettimeofday(&tv, nullptr);
-    result.setTime((double) tv.tv_sec + tv.tv_usec*(1.0E-6));
   }
 
   mutex.unlock();

--- a/src/shared/capture/captureinterface.cpp
+++ b/src/shared/capture/captureinterface.cpp
@@ -48,6 +48,7 @@ void CaptureInterface::readAllParameterValues() {
 bool CaptureInterface::copyAndConvertFrame(const RawImage & src, RawImage & target) {
   target.ensure_allocation(target.getColorFormat(),src.getWidth(),src.getHeight());
   target.setTime(src.getTime());
+  target.setTimeCam ( src.getTimeCam() );
   memcpy(target.getData(),src.getData(),src.getNumBytes());
   return true;
 }

--- a/src/shared/capture/capturev4l.cpp
+++ b/src/shared/capture/capturev4l.cpp
@@ -286,8 +286,8 @@ bool GlobalV4Linstance::captureFrame(RawImage *pImage, uint32_t pixel_format, in
               gettimeofday(&tv,NULL);
               pImage->setTime((double)tv.tv_sec + tv.tv_usec*(1.0E-6));
               */
-              pImage->setTime((double)_img->timestamp.tv_sec +
-                              _img->timestamp.tv_usec * (1.0E-6));
+              pImage->setTimeCam((double)_img->timestamp.tv_sec +
+                           (double) _img->timestamp.tv_usec * (1.0E-6));
               bSuccess = true;
             }
             unlock();
@@ -1434,6 +1434,7 @@ bool CaptureV4L::convertFrame(const RawImage & src, RawImage & target, ColorForm
         //target.setFormat(output_fmt);
     }
     target.setTime(src.getTime());
+    target.setTimeCam ( src.getTimeCam() );
     if (output_fmt==src_fmt) {
         //just do a memcpy
         memcpy(target.getData(),src.getData(),src.getNumBytes());

--- a/src/shared/proto/messages_robocup_ssl_detection.proto
+++ b/src/shared/proto/messages_robocup_ssl_detection.proto
@@ -1,32 +1,57 @@
 syntax = "proto2";
 
 message SSL_DetectionBall {
+  // Confidence in [0-1] of the detection
   required float  confidence = 1;
   optional uint32 area       = 2;
+  // X-coordinate in [mm] in global ssl-vision coordinate system
   required float  x          = 3;
+  // Y-coordinate in [mm] in global ssl-vision coordinate system
   required float  y          = 4;
+  // Z-coordinate in [mm] in global ssl-vision coordinate system
+  // Not supported by ssl-vision, but might be set by simulators
   optional float  z          = 5;
+  // X-coordinate in [pixel] in the image
   required float  pixel_x    = 6;
+  // Y-coordinate in [pixel] in the image
   required float  pixel_y    = 7;
 }
 
 message SSL_DetectionRobot {
+  // Confidence in [0-1] of the detection
   required float  confidence  =  1;
+  // Id of the robot
   optional uint32 robot_id    =  2;
+  // X-coordinate in [mm] in global ssl-vision coordinate system
   required float  x           =  3;
+  // Y-coordinate in [mm] in global ssl-vision coordinate system
   required float  y           =  4;
+  // Orientation in [rad]
   optional float  orientation =  5;
+  // X-coordinate in [pixel] in the image
   required float  pixel_x     =  6;
+  // Y-coordinate in [pixel] in the image
   required float  pixel_y     =  7;
+  // Height, as configured in ssl-vision for the respective team
   optional float  height      =  8;
 }
 
 message SSL_DetectionFrame {
-  required uint32             frame_number  = 1;
-  required double             t_capture     = 2;
-  required double             t_sent        = 3;
-  required uint32             camera_id     = 4;
-  repeated SSL_DetectionBall  balls         = 5;
-  repeated SSL_DetectionRobot robots_yellow = 6;
-  repeated SSL_DetectionRobot robots_blue   = 7;
+  // monotonously increasing frame number
+  required uint32             frame_number     = 1;
+  // Unix timestamp in [seconds] at which the image has been received by ssl-vision
+  required double             t_capture        = 2;
+  // Unix timestamp in [seconds] at which this message has been sent to the network
+  required double             t_sent           = 3;
+  // Camera timestamp in [seconds] as reported by the camera, if supported
+  // This is not necessarily a unix timestamp
+  optional double             t_capture_camera = 8;
+  // Identifier of the camera
+  required uint32             camera_id        = 4;
+  // Detected balls
+  repeated SSL_DetectionBall  balls            = 5;
+  // Detected yellow robots
+  repeated SSL_DetectionRobot robots_yellow    = 6;
+  // Detected blue robots
+  repeated SSL_DetectionRobot robots_blue      = 7;
 }

--- a/src/shared/util/rawimage.cpp
+++ b/src/shared/util/rawimage.cpp
@@ -24,17 +24,16 @@
 
 RawImage::RawImage()
 {
-  data=0;
+  data= nullptr;
   width=0;
   height=0;
   format=COLOR_UNDEFINED;
   time=0.0;
+  time_cam=0;
 }
 
 
-RawImage::~RawImage()
-{
-}
+RawImage::~RawImage() = default;
 
 
 int RawImage::getWidth() const
@@ -55,6 +54,11 @@ ColorFormat RawImage::getColorFormat() const
 double RawImage::getTime() const
 {
   return time;
+}
+
+double RawImage::getTimeCam() const
+{
+  return time_cam;
 }
 
 unsigned char * RawImage::getData() const
@@ -104,20 +108,23 @@ void RawImage::setTime(double t)
   time=t;
 }
 
+void RawImage::setTimeCam(double t)
+{
+  time_cam=t;
+}
+
 void RawImage::setData(unsigned char * d)
 {
-  if (data!=0) delete[] data;
+  delete[] data;
   data=d;
 }
 
 void  RawImage::allocate (ColorFormat fmt, int w, int h)
 {
   if(w >= 0 && h >= 0) {
-    if (data!=0) {
-      delete[] data;
-    }
+    delete[] data;
     if (w==0 && h==0) {
-      data=0;
+      data=nullptr;
     } else {
       data=new unsigned char[computeImageSize(fmt,w*h)];
     }
@@ -129,7 +136,7 @@ void  RawImage::allocate (ColorFormat fmt, int w, int h)
 
 void  RawImage::ensure_allocation (ColorFormat fmt, int w, int h)
 {
-  if(data == 0 || format != fmt || width != w || height!=h) {
+  if(data == nullptr || format != fmt || width != w || height!=h) {
     allocate(fmt,w,h);
   }
 }
@@ -146,7 +153,7 @@ void RawImage::deepCopyFromRawImage(const RawImage & img, bool copyMetaData)
 void RawImage::clear()
 {
   allocate(getColorFormat(),0,0);
-};
+}
 
 int RawImage::computeImageSize(ColorFormat fmt, int pixelCount)
 {

--- a/src/shared/util/rawimage.h
+++ b/src/shared/util/rawimage.h
@@ -40,19 +40,22 @@ class RawImage : public ImageInterface
 {
   protected:
   /// pointer to capture buffer
-  unsigned char * data;
+  unsigned char * data = nullptr;
 
   /// width of the image in pixels
-  int width;
+  int width = 0;
 
   /// height of the image in pixels
-  int height;
+  int height = 0;
 
   /// encoding format of the image
-  ColorFormat format;
+  ColorFormat format = COLOR_UNDEFINED;
 
-  /// capture timestamp of the image
-  double   time;
+  /// capture timestamp of the image in [s]
+  double time = 0.0;
+
+  /// capture timestamp of the image in [ns]
+  double time_cam = 0;
 
   public:
   RawImage();
@@ -64,6 +67,7 @@ class RawImage : public ImageInterface
   int getHeight() const;
   ColorFormat getColorFormat() const;
   double getTime() const;
+    double getTimeCam() const;
   unsigned char * getData() const;
   int getNumBytes() const;
   int getNumColorBlocks() const;
@@ -77,6 +81,7 @@ class RawImage : public ImageInterface
   void setWidth(int w);
   void setHeight(int h);
   void setTime(double t);
+  void setTimeCam(double t);
   void setData(unsigned char * d);
   void allocate (ColorFormat fmt, int w, int h);
   void ensure_allocation (ColorFormat fmt, int w, int h);


### PR DESCRIPTION
The time from the camera can be useful, but it comes from a different clock. Setting t_capture to the camera time causes issues when the processing time is calculated with t_sent - t_capture. Thus, the camera timestamp is now added separately to the detection frame.