### PR TITLE
Implement OpenCV Video source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(Qt5Core REQUIRED)
 find_package(Qt5Widgets REQUIRED)
 find_package(Qt5OpenGL REQUIRED)
 # Note: Bluefox SDK is not compatible with some components of OpenCV. Take care when enabling more.
-find_package(OpenCV REQUIRED COMPONENTS core imgproc imgcodecs )
+find_package(OpenCV REQUIRED COMPONENTS core imgproc imgcodecs videoio)
 
 include(src/shared/CMakeLists.txt.inc)
 

--- a/src/app/capture_thread.h
+++ b/src/app/capture_thread.h
@@ -76,6 +76,7 @@ protected:
   CaptureInterface * captureBlueFox3 = nullptr;
   CaptureInterface * captureFlycap = nullptr;
   CaptureInterface * captureFiles = nullptr;
+  CaptureInterface * captureVideo = nullptr;
   CaptureInterface * captureGenerator = nullptr;
   CaptureInterface * captureBasler = nullptr;
   CaptureInterface * captureSpinnaker = nullptr;
@@ -92,6 +93,7 @@ protected:
   VarList * flycap = nullptr;
   VarList * generator = nullptr;
   VarList * fromfile = nullptr;
+  VarList * video = nullptr;
   VarList * basler = nullptr;
   VarList * spinnaker = nullptr;
   VarList * splitter = nullptr;

--- a/src/shared/CMakeLists.txt.inc
+++ b/src/shared/CMakeLists.txt.inc
@@ -14,6 +14,7 @@ include_directories(${shared_dir}/vartypes/xml)
 
 set (SHARED_SRCS
 	${shared_dir}/capture/capturefromfile.cpp
+	${shared_dir}/capture/capture_video.cpp
 	${shared_dir}/capture/capture_generator.cpp
 	${shared_dir}/capture/captureinterface.cpp
 

--- a/src/shared/capture/capture_video.cpp
+++ b/src/shared/capture/capture_video.cpp
@@ -39,6 +39,11 @@ RawImage CaptureVideo::getFrame() {
   img.ensure_allocation(ColorFormat::COLOR_RGB8, factor*frame.cols, factor*frame.rows);
   cv::Mat dstImg(img.getHeight(), img.getWidth(), CV_8UC3, img.getData());
 
+  /* ssl-vision expects typical color images scaled up from the raw bayer matrix
+   * (4 sensor fields RG-GB are interpolated into four RGB pixels).
+   * To support downscaled image formats (4 color fields RG-GB into 1 RGB value)
+   * where ssl-vision needs the interpolated resolution to work as usual
+   * this upscaling option has been added. */
   if (v_cap_upscale->getBool()) {
     cv::resize(frame, dstImg, dstImg.size());
     cvtColor(dstImg, dstImg, cv::COLOR_BGR2RGB);
@@ -53,7 +58,9 @@ RawImage CaptureVideo::getFrame() {
   return img;
 }
 
-void CaptureVideo::releaseFrame() {}
+void CaptureVideo::releaseFrame() {
+  // frame and img are not cleared here to prevent unnecessary reallocation with the next frame.
+}
 
 
 bool CaptureVideo::startCapture() {

--- a/src/shared/capture/capture_video.cpp
+++ b/src/shared/capture/capture_video.cpp
@@ -30,7 +30,6 @@ CaptureVideo::CaptureVideo(VarList* settings) : CaptureInterface(settings) {
 
 
 RawImage CaptureVideo::getFrame() {
-  cv::Mat frame;
   if(!capture.read(frame)) {
     std::cout << "End of video stream reached" << std::endl;
     return img;
@@ -54,13 +53,12 @@ RawImage CaptureVideo::getFrame() {
   return img;
 }
 
-void CaptureVideo::releaseFrame() {
-  //img.clear();
-}
+void CaptureVideo::releaseFrame() {}
 
 
 bool CaptureVideo::startCapture() {
   timestamp = 0.0;
+  frame = cv::Mat();
   capture = cv::VideoCapture(v_cap_file->getString());
   is_capturing = capture.isOpened();
   return is_capturing;
@@ -68,6 +66,7 @@ bool CaptureVideo::startCapture() {
 
 bool CaptureVideo::stopCapture() {
   capture.release();
+  frame.release();
   is_capturing = false;
   return !is_capturing;
 }

--- a/src/shared/capture/capture_video.cpp
+++ b/src/shared/capture/capture_video.cpp
@@ -1,0 +1,82 @@
+//========================================================================
+//  This software is free: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License Version 3,
+//  as published by the Free Software Foundation.
+//
+//  This software is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  Version 3 in the file COPYING that came with this distribution.
+//  If not, see <http://www.gnu.org/licenses/>.
+//========================================================================
+/*!
+  \file    capture_video.cpp
+  \brief   C++ Implementation: CaptureVideo
+  \author  Felix Weinmann, (C) 2024
+*/
+//========================================================================
+
+#include "capture_video.h"
+
+#include <opencv2/imgproc.hpp>
+
+CaptureVideo::CaptureVideo(VarList* settings) : CaptureInterface(settings) {
+  settings->addChild(v_cap_file = new VarString("file", ""));
+  settings->addChild(v_cap_upscale = new VarBool("upscale", false));
+}
+
+
+RawImage CaptureVideo::getFrame() {
+  cv::Mat frame;
+  if(!capture.read(frame)) {
+    std::cout << "End of video stream reached" << std::endl;
+    return img;
+  }
+
+  int factor = v_cap_upscale->getBool() ? 2 : 1;
+  img.ensure_allocation(ColorFormat::COLOR_RGB8, factor*frame.cols, factor*frame.rows);
+  cv::Mat dstImg(img.getHeight(), img.getWidth(), CV_8UC3, img.getData());
+
+  if (v_cap_upscale->getBool()) {
+    cv::resize(frame, dstImg, dstImg.size());
+    cvtColor(dstImg, dstImg, cv::COLOR_BGR2RGB);
+  } else {
+    // convert to default ssl-vision format (RGB8)
+    cvtColor(frame, dstImg, cv::COLOR_BGR2RGB);
+  }
+
+  timestamp += 1.0/capture.get(cv::CAP_PROP_FPS);
+  img.setTimeCam(timestamp);
+
+  return img;
+}
+
+void CaptureVideo::releaseFrame() {
+  //img.clear();
+}
+
+
+bool CaptureVideo::startCapture() {
+  timestamp = 0.0;
+  capture = cv::VideoCapture(v_cap_file->getString());
+  is_capturing = capture.isOpened();
+  return is_capturing;
+}
+
+bool CaptureVideo::stopCapture() {
+  capture.release();
+  is_capturing = false;
+  return !is_capturing;
+}
+
+
+bool CaptureVideo::isCapturing() {
+  return is_capturing;
+}
+
+string CaptureVideo::getCaptureMethodName() const {
+  return "Video";
+}

--- a/src/shared/capture/capture_video.h
+++ b/src/shared/capture/capture_video.h
@@ -41,6 +41,7 @@ class CaptureVideo : public CaptureInterface {
   VarString* v_cap_file;
   VarBool* v_cap_upscale;
 
+  cv::Mat frame;
   cv::VideoCapture capture;
   RawImage img;
   double timestamp;

--- a/src/shared/capture/capture_video.h
+++ b/src/shared/capture/capture_video.h
@@ -1,0 +1,51 @@
+//========================================================================
+//  This software is free: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License Version 3,
+//  as published by the Free Software Foundation.
+//
+//  This software is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  Version 3 in the file COPYING that came with this distribution.
+//  If not, see <http://www.gnu.org/licenses/>.
+//========================================================================
+/*!
+  \file    capture_video.h
+  \brief   C++ Interface: CaptureVideo
+  \author  Felix Weinmann, (C) 2024
+*/
+//========================================================================
+
+#ifndef SSL_VISION_CAPTURE_VIDEO_H
+#define SSL_VISION_CAPTURE_VIDEO_H
+
+#include <opencv2/videoio.hpp>
+
+#include "captureinterface.h"
+
+class CaptureVideo : public CaptureInterface {
+ public:
+  explicit CaptureVideo(VarList* settings);
+
+  RawImage getFrame() override;
+  bool isCapturing() override;
+  void releaseFrame() override;
+  bool startCapture() override;
+  bool stopCapture() override;
+  string getCaptureMethodName() const override;
+
+ private:
+  VarString* v_cap_file;
+  VarBool* v_cap_upscale;
+
+  cv::VideoCapture capture;
+  RawImage img;
+  double timestamp;
+
+  bool is_capturing = false;
+};
+
+#endif  // SSL_VISION_CAPTURE_VIDEO_H

--- a/src/shared/capture/captureinterface.cpp
+++ b/src/shared/capture/captureinterface.cpp
@@ -46,6 +46,9 @@ void CaptureInterface::readAllParameterValues() {
 }
 
 bool CaptureInterface::copyAndConvertFrame(const RawImage & src, RawImage & target) {
+  if(target.getColorFormat() == COLOR_UNDEFINED)
+    target.setColorFormat(src.getColorFormat());
+
   target.ensure_allocation(target.getColorFormat(),src.getWidth(),src.getHeight());
   target.setTime(src.getTime());
   target.setTimeCam ( src.getTimeCam() );

--- a/src/shared/capture/captureinterface.cpp
+++ b/src/shared/capture/captureinterface.cpp
@@ -46,7 +46,7 @@ void CaptureInterface::readAllParameterValues() {
 }
 
 bool CaptureInterface::copyAndConvertFrame(const RawImage & src, RawImage & target) {
-  if(target.getColorFormat() == COLOR_UNDEFINED)
+  if(target.getColorFormat() == COLOR_UNDEFINED) // pixel size of COLOR_UNDEFINED is 0, causing a segmentation fault during the memcpy
     target.setColorFormat(src.getColorFormat());
 
   target.ensure_allocation(target.getColorFormat(),src.getWidth(),src.getHeight());

--- a/src/shared/capture/captureinterface.cpp
+++ b/src/shared/capture/captureinterface.cpp
@@ -46,10 +46,8 @@ void CaptureInterface::readAllParameterValues() {
 }
 
 bool CaptureInterface::copyAndConvertFrame(const RawImage & src, RawImage & target) {
-  if(target.getColorFormat() == COLOR_UNDEFINED) // pixel size of COLOR_UNDEFINED is 0, causing a segmentation fault during the memcpy
-    target.setColorFormat(src.getColorFormat());
-
-  target.ensure_allocation(target.getColorFormat(),src.getWidth(),src.getHeight());
+  target.setColorFormat(src.getColorFormat());
+  target.ensure_allocation(src.getColorFormat(),src.getWidth(),src.getHeight());
   target.setTime(src.getTime());
   target.setTimeCam ( src.getTimeCam() );
   memcpy(target.getData(),src.getData(),src.getNumBytes());


### PR DESCRIPTION
Enables the usage of typical video formats as source for ssl-vision for testing and benchmarking.

The impact of the additional OpenCV module videoio on the Bluefox SDK support has not been tested.