### PR TITLE
Update ER-Force robot height to 148mm

### DIFF
--- a/robocup-ssl-teams.xml
+++ b/robocup-ssl-teams.xml
@@ -29,7 +29,7 @@
 			ER-Force
 		</Var>
 		<Var name="Robot Height (mm)" type="double" minval="" maxval="">
-			150.000000
+			148.000000
 		</Var>
 	</Var>
 	<Var name="Immortals" type="list">


### PR DESCRIPTION
Our robot height changed a little (2mm), this updates the vision config to match it.

Were can I adjust the robot height for the vision processor?